### PR TITLE
remove unnecessary use of bosh vars file from s3

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -75,9 +75,6 @@ jobs:
     - get: deploy-logs-opensearch-config
       trigger: true
       passed: [set-self]
-    - get: common-secrets
-      resource: common-development
-      trigger: true
     - get: opensearch-release
       trigger: true
     - get: opensearch-stemcell-jammy
@@ -95,7 +92,6 @@ jobs:
           tag: ((harden-concourse-task-tag))
       inputs:
       - name: deploy-logs-opensearch-config
-      - name: common-secrets
       run:
         path: sh
         args:
@@ -104,7 +100,6 @@ jobs:
           SPRUCE_FILE_BASE_PATH=deploy-logs-opensearch-config spruce merge \
             deploy-logs-opensearch-config/opensearch-deployment.yml \
             deploy-logs-opensearch-config/opensearch-jobs.yml \
-            common-secrets/opensearch-development.yml \
             deploy-logs-opensearch-config/opensearch-development.yml \
             > opensearch-manifest/manifest.yml
       outputs:
@@ -195,13 +190,6 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook-url))
-
-- name: common-development
-  type: s3-iam
-  source:
-    bucket: ((bosh-s3-vars-bucket))
-    versioned_file: opensearch-development.yml
-    region_name: ((aws-region))
 
 - name: opensearch-development-deployment
   type: bosh-deployment

--- a/opensearch-deployment.yml
+++ b/opensearch-deployment.yml
@@ -1,5 +1,3 @@
-director_uuid: (( param "Please set the UUID of your BOSH Director" ))
-
 features:
   use_dns_addresses: false
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove BOSH vars file that was setting `director_uuid` since it's not required in BOSH CLI v2: https://bosh.io/docs/manifest-v2/#deployment

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
