### PR TITLE
update pipeline to use general task image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -19,17 +19,11 @@ jobs:
       resource: opensearch-final-builds-dir-tarball
     - get: releases-dir-tarball
       resource: opensearch-releases-dir-tarball
+    - get: general-task
   - task: run-tests
     config:
       platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          aws_access_key_id: ((ecr_aws_key))
-          aws_secret_access_key: ((ecr_aws_secret))
-          repository: harden-concourse-task
-          aws_region: us-gov-west-1
-          semver_constraint: ">= 1.0.0"
+      image: general-task
       inputs:
       - name: release-git-repo
       run:
@@ -79,17 +73,11 @@ jobs:
       trigger: true
     - get: opensearch-stemcell-jammy
       trigger: true
+    - get: general-task
   - task: opensearch-manifest
     config:
       platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          aws_access_key_id: ((ecr_aws_key))
-          aws_secret_access_key: ((ecr_aws_secret))
-          repository: harden-concourse-task
-          aws_region: us-gov-west-1
-          tag: ((harden-concourse-task-tag))
+      image: general-task
       inputs:
       - name: deploy-logs-opensearch-config
       run:
@@ -200,7 +188,25 @@ resources:
     ca_cert: ((bosh-director-info.development.ca_cert))
     deployment: logs-opensearch
 
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
 resource_types:
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
 - name: slack-notification
   type: docker-image
   source:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update pipeline to use general task image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating pipeline to use latest, hardened `general-task` image