### PR TITLE
add maintenance instance group and opensearch_config job

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -1,6 +1,6 @@
 instance_groups:
 #######################################################
-#First deploy group - opensearch_manager
+#First deploy group - opensearch_manager, maintenance
 #######################################################
 - name: opensearch_manager
   instances: 3
@@ -23,12 +23,6 @@ instance_groups:
         node:
           allow_cluster_manager: true
           allow_data: false
-        http:
-          ssl:
-            ca: ((opensearch_node.ca))
-            certificate: ((opensearch_node.certificate))
-            private_key: ((opensearch_node.private_key))
-        http_host: 127.0.0.1
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
     release: opensearch
@@ -39,6 +33,39 @@ instance_groups:
   vm_type: t3.large
   networks:
    - name: services
+
+- name: maintenance
+  instances: 1
+  vm_extensions: [errand-profile]
+  jobs:
+  - name: bpm
+    release: bpm
+  - name: opensearch
+    release: openearch
+    consumes:
+      opensearch:
+        from: opensearch_manager
+    properties:
+      opensearch:
+        clustername: opensearch
+        limits:
+          fd: 131072 # 2 ** 17
+        jvm_options:
+          - "-Dlog4j2.formatMsgNoLookups=true"
+  - name: opensearch_config
+    release: logsearch
+    properties:
+      opensearch_config:
+        component_templates:
+        - shards-and-replicas: /var/vcap/jobs/opensearch_config/index-templates/shards-and-replicas.json
+        - index-settings: /var/vcap/jobs/opensearch_config/index-templates/index-settings.json
+        - index-mappings: /var/vcap/jobs/opensearch_config/index-templates/index-mappings.json
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+  update:
+    serial: true # Block on this job to create deploy group 1
 
 #########################################################
 #2nd deploy group - opensearch_data, opensearch_dashboards, ingestors

--- a/opsfiles/enable-node-tls.yml
+++ b/opsfiles/enable-node-tls.yml
@@ -31,6 +31,23 @@
     certificate: ((opensearch_node.certificate))
     private_key: ((opensearch_node.private_key))
 
+# maintenance
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=opensearch/properties/opensearch/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=opensearch/properties/opensearch/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=opensearch/properties/opensearch/node/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=opensearch/properties/opensearch/http?/ssl?
+  value: *http-tls-properties
+
 # opensearch_data
 - type: replace
   path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties/opensearch/http_host?


### PR DESCRIPTION
## Changes proposed in this pull request:

- add maintenance instance group and opensearch_config job

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adding deployment of a new BOSH job
