### PR TITLE
fix conditional property path in opsfile

### DIFF
--- a/opsfiles/enable-node-tls.yml
+++ b/opsfiles/enable-node-tls.yml
@@ -25,7 +25,7 @@
     private_key: ((opensearch_node.private_key))
 
 - type: replace
-  path: /instance_groups/name=opensearch_manager/jobs/name=opensearch/properties/opensearch/http/ssl?
+  path: /instance_groups/name=opensearch_manager/jobs/name=opensearch/properties/opensearch/http?/ssl?
   value: &http-tls-properties
     ca: ((opensearch_node.ca))
     certificate: ((opensearch_node.certificate))


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
