### PR TITLE
update job manifest to enable proxy authentication

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -102,7 +102,6 @@ jobs:
         CF_USERNAME: ((cf-username-development))
         CF_PASSWORD: ((cf-password-development))
         CF_SYSTEM_DOMAIN: ((cf-system-domain-development))
-        BOSH_LOG_LEVEL: debug
   - put: opensearch-development-deployment
     params:
       manifest: opensearch-manifest/manifest.yml

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -8,9 +8,12 @@ instance_groups:
   - name: bpm
     release: bpm
   - name: opensearch
-    consumes: &consumes-opensearch-manager
-      opensearch:
+    consumes:
+      opensearch: &consumes-opensearch-manager
         from: opensearch_manager
+        ip_addresses: true
+      opensearch_dashboards: &consumes-opensearch-dashboards
+        from: opensearch_dashboards
         ip_addresses: true
     provides:
       opensearch:
@@ -42,7 +45,9 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       opensearch:
         clustername: opensearch
@@ -63,11 +68,10 @@ instance_groups:
         platform_index_component_name: index-mappings-platform-lfc
         shards_and_replicas_component_name: shards-and-replicas
     release: opensearch
-  - consumes:
-      opensearch:
-        from: opensearch_manager
-        ip_addresses: true
-    name: curator
+  - name: curator
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       curator:
         actions:
@@ -113,7 +117,9 @@ instance_groups:
     release: opensearch
   - name: opensearch_config
     release: opensearch
-    consumes: *consumes-opensearch-manager
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       opensearch_config:
         component_templates:
@@ -143,8 +149,10 @@ instance_groups:
   jobs:
   - name: bpm
     release: bpm
-  - consumes: *consumes-opensearch-manager
-    name: opensearch
+  - name: opensearch
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       opensearch:
         jvm_options:
@@ -202,17 +210,19 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       opensearch:
         heap_size: 1G
         http_host: 127.0.0.1
         jvm_options:
         - -Dlog4j2.formatMsgNoLookups=true
-  - consumes:
-      opensearch:
-        from: opensearch_manager
-    name: ingestor_syslog
+  - name: ingestor_syslog
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       logstash:
         jvm_options:
@@ -268,7 +278,9 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
     properties:
       opensearch:
         node:
@@ -304,9 +316,15 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager
+    consumes:
+      <<: *consumes-opensearch-manager
+      <<: *&consumes-opensearch-dashboards
   - name: opensearch_dashboards
-    consumes: *consumes-opensearch-manager
+    consumes:
+      <<: *consumes-opensearch-manager
+    provides:
+      opensearch_dashboards:
+        as: opensearch_dashboards
     properties:
       opensearch_dashboards:
         config_options:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update job manifest to enable proxy authentication

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Enabling proxy authentication will allow us to use UAA authentication to validate user identity and translate that identity into a set of authorized permissions for viewing logs in Opensearch
