### PR TITLE
Create proxy auth opsfile

### DIFF
--- a/opensearch-deployment.yml
+++ b/opensearch-deployment.yml
@@ -17,3 +17,8 @@ releases:
 - {name: routing, version: latest}
 - {name: bosh-dns-aliases, version: latest}
 - {name: bpm, version: latest}
+
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest

--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -19,6 +19,11 @@ instance_groups:
         deployment: cf-development
         from: nats-tls
     properties:
+      nats:
+        tls:
+          client_cert: ((/bosh/cf-development/nats_client_cert.certificate))
+          client_key: ((/bosh/cf-development/nats_client_cert.private_key))
+          enabled: true
       route_registrar:
         routes:
         - name: opensearch-dashboard
@@ -59,10 +64,3 @@ instance_groups:
       cloudfoundry:
         api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
         firehose_client_secret: ((logs_opensearch_firehose_client_secret))
-
-
-
-stemcells:
-- alias: default
-  os: ubuntu-jammy
-  version: latest

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -8,12 +8,9 @@ instance_groups:
   - name: bpm
     release: bpm
   - name: opensearch
-    consumes: &consumes-opensearch-manager-and-dashboards
-      opensearch: &consumes-opensearch-manager
+    consumes: &consumes-opensearch-manager
+      opensearch:
         from: opensearch_manager
-        ip_addresses: true
-      opensearch_dashboards: &consumes-opensearch-dashboards
-        from: opensearch_dashboards
         ip_addresses: true
     provides:
       opensearch:
@@ -45,7 +42,7 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch:
         clustername: opensearch
@@ -67,7 +64,7 @@ instance_groups:
         shards_and_replicas_component_name: shards-and-replicas
     release: opensearch
   - name: curator
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       curator:
         actions:
@@ -113,7 +110,7 @@ instance_groups:
     release: opensearch
   - name: opensearch_config
     release: opensearch
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch_config:
         component_templates:
@@ -144,7 +141,7 @@ instance_groups:
   - name: bpm
     release: bpm
   - name: opensearch
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch:
         jvm_options:
@@ -202,7 +199,7 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch:
         heap_size: 1G
@@ -210,7 +207,7 @@ instance_groups:
         jvm_options:
         - -Dlog4j2.formatMsgNoLookups=true
   - name: ingestor_syslog
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       logstash:
         jvm_options:
@@ -266,7 +263,7 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch:
         node:
@@ -302,14 +299,9 @@ instance_groups:
     release: bpm
   - name: opensearch
     release: opensearch
-    consumes: *consumes-opensearch-manager-and-dashboards
+    consumes: *consumes-opensearch-manager
   - name: opensearch_dashboards
-    consumes:
-      opensearch:
-        <<: *consumes-opensearch-manager
-    provides:
-      opensearch_dashboards:
-        as: opensearch_dashboards
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch_dashboards:
         config_options:
@@ -331,31 +323,8 @@ instance_groups:
       nats-tls:
         deployment: cf-development
         from: nats-tls
-    properties:
-      nats:
-        tls:
-          client_cert: ((/bosh/cf-development/nats_client_cert.certificate))
-          client_key: ((/bosh/cf-development/nats_client_cert.private_key))
-          enabled: true
-      route_registrar:
-        routes:
-        - name: opensearch-dashboard
-          port: 5601
-          registration_interval: 2s
-          timeout: 1s
-          uris:
-          - logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov
     release: routing
   - name: bosh-dns-aliases
-    properties:
-      aliases:
-      - domain: nats.service.cf.internal
-        targets:
-        - deployment: cf-development
-          domain: bosh
-          instance_group: nats
-          network: default
-          query: '*'
     release: bosh-dns-aliases
   persistent_disk: 10240
   stemcell: default

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -28,7 +28,6 @@ instance_groups:
         node:
           allow_cluster_manager: true
           allow_data: false
-        enable_proxy_auth: true
     release: opensearch
   azs:
   - z1
@@ -284,7 +283,6 @@ instance_groups:
           indices.query.bool.max_clause_count: 2048
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
-        enable_proxy_auth: true
   persistent_disk: 10240
   stemcell: default
   azs: [z1]
@@ -324,7 +322,6 @@ instance_groups:
           timeout: 600
         memory_limit: 75
         opensearch:
-          enable_proxy_auth: true
     provides:
       opensearch-dashboard:
         as: opensearch_link

--- a/opsfiles/enable-proxy-auth.yml
+++ b/opsfiles/enable-proxy-auth.yml
@@ -1,0 +1,35 @@
+---
+
+# opensearch_manager
+- type: replace
+  path: /instance_groups/name=opensearch_manager/jobs/name=opensearch/properties/opensearch?/enable_proxy_auth
+  value: true
+
+# maintenance
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=opensearch/properties/opensearch?/enable_proxy_auth
+  value: true
+
+# opensearch_data
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties/opensearch?/enable_proxy_auth
+  value: true
+
+# opensearch_dashboards
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
+  value: true
+
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=opensearch_dashboards/properties?/opensearch_dashboards?/opensearch?/enable_proxy_auth
+  value: true
+
+# archiver
+- type: replace
+  path: /instance_groups/name=archiver/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
+  value: true
+
+# ingestor
+- type: replace
+  path: /instance_groups/name=ingestor/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
+  value: true


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/800

## Changes proposed in this pull request:

Refactor deployment config to enable proxy auth via an opsfile. See #20 for initial implementation of proxy auth

- [create opsfile for enabling proxy auth](https://github.com/cloud-gov/deploy-logs-opensearch/commit/633eddeb828d1028e7d8219b7ee4a0255512c967)
- [refactor deployment config](https://github.com/cloud-gov/deploy-logs-opensearch/commit/2e794523d340c72e4f21047001fdb5eab7d7ac57)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

See #20 
