### PR TITLE
restore base deployment lookup file

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -213,9 +213,10 @@ instance_groups:
           max_bytes: 30gb
       logstash_parser:
         deployment_dictionary:
+        - /var/vcap/packages/base-logstash-filters/deployment_lookup.yml
         - /var/vcap/jobs/parser-config-cf/config/deployment_lookup.yml
         filters:
-        - logs-for-cf: /var/vcap/packages/cf-logs-logstash-filters/logstash-filters-default.conf
+        - logs-for-cf: /var/vcap/packages/cf-logstash-filters/logstash-filters-default.conf
         opensearch:
           data_hosts:
           - localhost


### PR DESCRIPTION
## Changes proposed in this pull request:

Revert #28 as it seems that these files are used generally for CF app logs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
