### PR TITLE
Rename jobs

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -51,18 +51,22 @@ instance_groups:
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
   - name: upload_opensearch_config
-    release: opensearch
-    consumes: *consumes-opensearch-manager
+    consumes:
+      opensearch:
+        from: opensearch_manager
+        ip_addresses: true
     properties:
       opensearch_config:
         component_templates:
         - shards-and-replicas: /var/vcap/jobs/upload_opensearch_config/index-templates/shards-and-replicas.json
         - index-settings: /var/vcap/jobs/upload_opensearch_config/index-templates/index-settings.json
-        - index-mappings: /var/vcap/jobs/upload_opensearch_config/index-templates/index-mappings.json
-        - component-index-mappings-base: /var/vcap/jobs/opensearch_templates/component-index-mappings.json
+        - index-template: /var/vcap/jobs/upload_opensearch_config/index-templates/index-template.json
+        - component-index-mappings-base: /var/vcap/jobs/opensearch_templates/component-index-mappings-base.json
         - component-index-mappings-app-cf: /var/vcap/jobs/opensearch_templates/component-index-mappings-app.json
+        - component-index-mappings-platform: /var/vcap/jobs/opensearch_templates/component-index-mappings-platform.json
         index_templates:
-        - index-mappings-app-cf: /var/vcap/jobs/opensearch_templates/index-mappings-app.json
+        - index-template-app-cf: /var/vcap/jobs/opensearch_templates/index-template-app.json
+    release: opensearch
   - name: opensearch_templates
     properties:
       opensearch_config:

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -59,11 +59,11 @@ instance_groups:
         - shards-and-replicas: /var/vcap/jobs/upload_opensearch_config/index-templates/shards-and-replicas.json
         - index-settings: /var/vcap/jobs/upload_opensearch_config/index-templates/index-settings.json
         - index-mappings: /var/vcap/jobs/upload_opensearch_config/index-templates/index-mappings.json
-        - component-index-mappings-base: /var/vcap/jobs/opensearch_config_cf/component-index-mappings.json
-        - component-index-mappings-app-cf: /var/vcap/jobs/opensearch_config_cf/component-index-mappings-app.json
+        - component-index-mappings-base: /var/vcap/jobs/opensearch_templates/component-index-mappings.json
+        - component-index-mappings-app-cf: /var/vcap/jobs/opensearch_templates/component-index-mappings-app.json
         index_templates:
-        - index-mappings-app-cf: /var/vcap/jobs/opensearch_config_cf/index-mappings-app.json
-  - name: opensearch_config_cf
+        - index-mappings-app-cf: /var/vcap/jobs/opensearch_templates/index-mappings-app.json
+  - name: opensearch_templates
     properties:
       opensearch_config:
         app_index_component_name: component-index-mappings-app-cf

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -214,7 +214,7 @@ instance_groups:
       logstash_parser:
         deployment_dictionary:
         - /var/vcap/packages/base-logstash-filters/deployment_lookup.yml
-        - /var/vcap/jobs/parser-config-cf/config/deployment_lookup.yml
+        - /var/vcap/jobs/deployment_lookup_config/config/deployment_lookup.yml
         filters:
         - logs-for-cf: /var/vcap/packages/cf-logstash-filters/logstash-filters-default.conf
         opensearch:
@@ -244,7 +244,7 @@ instance_groups:
         host: 127.0.0.1
         port: 5514
     release: opensearch
-  - name: parser-config-cf
+  - name: deployment_lookup_config
     release: opensearch
   persistent_disk_type: logs_opensearch_ingestor
   stemcell: default

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -50,15 +50,15 @@ instance_groups:
           fd: 131072 # 2 ** 17
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
-  - name: opensearch_config
+  - name: upload_opensearch_config
     release: opensearch
     consumes: *consumes-opensearch-manager
     properties:
       opensearch_config:
         component_templates:
-        - shards-and-replicas: /var/vcap/jobs/opensearch_config/index-templates/shards-and-replicas.json
-        - index-settings: /var/vcap/jobs/opensearch_config/index-templates/index-settings.json
-        - index-mappings: /var/vcap/jobs/opensearch_config/index-templates/index-mappings.json
+        - shards-and-replicas: /var/vcap/jobs/upload_opensearch_config/index-templates/shards-and-replicas.json
+        - index-settings: /var/vcap/jobs/upload_opensearch_config/index-templates/index-settings.json
+        - index-mappings: /var/vcap/jobs/upload_opensearch_config/index-templates/index-mappings.json
         - component-index-mappings-base: /var/vcap/jobs/opensearch_config_cf/component-index-mappings.json
         - component-index-mappings-app-cf: /var/vcap/jobs/opensearch_config_cf/component-index-mappings-app.json
         index_templates:


### PR DESCRIPTION
## Changes proposed in this pull request:

Many of our jobs have names that are vague and don't really describe what the job is doing. This PR renames several of the jobs and some of the files within the jobs to better clarify their purpose

- [rename opensearch_config job to upload_opensearch_config](https://github.com/cloud-gov/deploy-logs-opensearch/commit/d2c608c67e91e74a6ae048adb0f8f167670aeac4)
- [rename jobs/parser-config-cf -> jobs/deployment_lookup_config](https://github.com/cloud-gov/deploy-logs-opensearch/commit/a18b377a8de928c5c7e83f894535fdc17057dfdd)
- [rename jobs/opensearch_config_cf ->  jobs/opensearch_templates](https://github.com/cloud-gov/deploy-logs-opensearch/commit/f7c554fc4433e6bd489dde90afe6bd06eae61a21) 
- [update template filenames for clarity](https://github.com/cloud-gov/deploy-logs-opensearch/commit/3151c5f710341543be26f2bdcf4b45ee22a35426)


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just renaming files for clarity
