### PR TITLE
Upload dashboard objects

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -131,7 +131,33 @@ jobs:
         :white_check_mark: Successfully deployed logs-opensearch on development
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
+- name: upload-dashboards-objects-development
+  serial_groups: [bosh-development]
+  plan:
+  - in_parallel:
+    - get: pipeline-tasks
+    - get: opensearch-release
+      trigger: true
+      passed: [deploy-opensearch-development]
+    - get: opensearch-stemcell-jammy
+      trigger: true
+      passed: [deploy-opensearch-development]
+    - get: deploy-logs-opensearch-config
+      passed: [deploy-opensearch-development]
+      trigger: true
+  - task: upload-dashboards-objects
+    file: pipeline-tasks/bosh-logs-errand.yml
+    params:
+      BOSH_ENVIRONMENT: ((bosh_environment))
+      BOSH_CLIENT: ((bosh_client))
+      BOSH_CLIENT_SECRET: ((bosh_client-secret))
+      BOSH_DEPLOYMENT: logs-opensearch
+      BOSH_ERRAND: upload-dashboards-objects
+      BOSH_FLAGS: "--keep-alive"
+      BOSH_CA_CERT: ((bosh_ca_cert_store.certificate))
+
 - name: smoke-tests-development
+  serial_groups: [bosh-development]
   plan:
   - in_parallel:
     - get: tests-timer

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -112,6 +112,7 @@ jobs:
       ops_files:
       - deploy-logs-opensearch-config/opsfiles/nats-tls-dev.yml
       - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
+      - deploy-logs-opensearch-config/opsfiles/enable-dashboards-tls.yml
       - deploy-logs-opensearch-config/opsfiles/enable-proxy-auth.yml
   on_failure:
     put: slack

--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -17,25 +17,10 @@ instance_groups:
   instances: 1
   jobs:
   - name: route_registrar
-    consumes:
-      nats-tls:
-        deployment: cf-development
-        from: nats-tls
     properties:
-      nats:
-        tls:
-          client_cert: ((/bosh/cf-development/nats_client_cert.certificate))
-          client_key: ((/bosh/cf-development/nats_client_cert.private_key))
-          enabled: true
       route_registrar:
-        routes:
-        - name: opensearch-dashboard
-          port: 5601
-          registration_interval: 2s
-          timeout: 1s
           uris:
           - logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov
-    release: routing
 
 - name: archiver
   instances: 1

--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -15,12 +15,6 @@ instance_groups:
 - name: opensearch_dashboards
   vm_type: t3.xlarge
   instances: 1
-  jobs:
-  - name: route_registrar
-    properties:
-      route_registrar:
-          uris:
-          - logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov
 
 - name: archiver
   instances: 1

--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -8,6 +8,9 @@ instance_groups:
 - name: opensearch_data
   instances: 3
   vm_type: t3.large
+  update:
+    max_in_flight: 2
+    canaries: 2
 
 - name: opensearch_dashboards
   vm_type: t3.xlarge
@@ -33,17 +36,6 @@ instance_groups:
           uris:
           - logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov
     release: routing
-  - name: bosh-dns-aliases
-    properties:
-      aliases:
-      - domain: nats.service.cf.internal
-        targets:
-        - deployment: cf-development
-          domain: bosh
-          instance_group: nats
-          network: default
-          query: '*'
-    release: bosh-dns-aliases
 
 - name: archiver
   instances: 1
@@ -68,3 +60,18 @@ instance_groups:
 - name: smoke-tests
   instances: 1
   vm_type: t3.small
+
+addons:
+- name: bosh-dns-aliases
+  jobs:
+  - name: bosh-dns-aliases
+    release: bosh-dns-aliases
+    properties:
+      aliases:
+      - domain: nats.service.cf.internal
+        targets:
+        - deployment: cf-development
+          domain: bosh
+          instance_group: nats
+          network: default
+          query: '*'

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -139,9 +139,9 @@ instance_groups:
         firehose_events:
         - LogMessage
         - ContainerMetric
-        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
-        user: (( grab $CF_USERNAME ))
-        password: (( grab $CF_PASSWORD ))
+        system_domain: ((system_domain))
+        user: ((dashboards_upload_user_name))
+        password: ((dashboards_upload_user_password))
       kibana_objects:
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/index-pattern/logs-app.json"}

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -132,6 +132,9 @@ instance_groups:
   - name: upload-dashboards-objects
     release: opensearch
     consumes:
+      opensearch:
+        from: opensearch_manager
+        ip_addresses: true
       opensearch_dashboards:
         from: opensearch_dashboards
         ip_addresses: true

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -339,10 +339,6 @@ instance_groups:
         health:
           timeout: 600
         memory_limit: 75
-    provides:
-      opensearch_dashboards:
-        as: opensearch_dashboards
-        ip_addresses: true
     release: opensearch
   vm_extensions:
   - 50GB_ephemeral_disk

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -58,10 +58,7 @@ instance_groups:
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
   - name: upload_opensearch_config
-    consumes:
-      opensearch:
-        from: opensearch_manager
-        ip_addresses: true
+    consumes: *consumes-opensearch-manager
     properties:
       opensearch_config:
         component_templates:
@@ -134,6 +131,10 @@ instance_groups:
     release: opensearch
   - name: upload-dashboards-objects
     release: opensearch
+    consumes:
+      opensearch_dashboards:
+        from: opensearch_dashboards
+        ip_addresses: true
     properties:
       cloudfoundry:
         firehose_events:
@@ -338,8 +339,9 @@ instance_groups:
           timeout: 600
         memory_limit: 75
     provides:
-      opensearch-dashboard:
-        as: opensearch_link
+      opensearch_dashboards:
+        as: opensearch_dashboards
+        ip_addresses: true
     release: opensearch
   - name: route_registrar
     consumes:

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -143,12 +143,11 @@ instance_groups:
         system_domain: ((system_domain))
         user: ((dashboards_upload_user_name))
         password: ((dashboards_upload_user_password))
-      kibana_objects:
-        upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/index-pattern/logs-app.json"}
-        - {type: search, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/search/app-*.json"}
-        - {type: visualization, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/visualization/App-*.json"}
-        - {type: dashboard, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/dashboard/App-*.json"}
+      upload_patterns:
+      - {type: index-pattern, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/index-pattern/logs-app.json"}
+      - {type: search, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/search/app-*.json"}
+      - {type: visualization, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/visualization/App-*.json"}
+      - {type: dashboard, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/dashboard/App-*.json"}
       opensearch_dashboards:
         host: opensearch_dashboards.opensearch.internal
   stemcell: default
@@ -345,6 +344,25 @@ instance_groups:
         as: opensearch_dashboards
         ip_addresses: true
     release: opensearch
+  - name: route_registrar
+    consumes:
+      nats-tls:
+        deployment: cf-development
+        from: nats-tls
+    properties:
+      nats:
+        tls:
+          client_cert: ((/bosh/cf-development/nats_client_cert.certificate))
+          client_key: ((/bosh/cf-development/nats_client_cert.private_key))
+          enabled: true
+      route_registrar:
+        routes:
+        - name: opensearch-dashboard
+          tls_port: 5601
+          registration_interval: 2s
+          timeout: 1s
+          server_cert_domain_san: "opensearch_dashboards.opensearch.internal"
+    release: routing
   vm_extensions:
   - 50GB_ephemeral_disk
   stemcell: default

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -132,6 +132,22 @@ instance_groups:
         purge_logs:
           retention_period: 90
     release: opensearch
+  - name: upload-dashboards-objects
+    release: opensearch
+    properties:
+      cloudfoundry:
+        firehose_events:
+        - LogMessage
+        - ContainerMetric
+        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+        user: (( grab $CF_USERNAME ))
+        password: (( grab $CF_PASSWORD ))
+      kibana_objects:
+        upload_patterns:
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/index-pattern/logs-app.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/search/app-*.json"}
+        - {type: visualization, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/visualization/App-*.json"}
+        - {type: dashboard, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/dashboard/App-*.json"}
   stemcell: default
   azs: [z1]
   vm_type: t3.large

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -135,9 +135,6 @@ instance_groups:
       opensearch:
         from: opensearch_manager
         ip_addresses: true
-      opensearch_dashboards:
-        from: opensearch_dashboards
-        ip_addresses: true
     properties:
       cloudfoundry:
         firehose_events:
@@ -152,6 +149,8 @@ instance_groups:
         - {type: search, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/search/app-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/visualization/App-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboard-objects/dashboard/App-*.json"}
+      opensearch_dashboards:
+        host: opensearch_dashboards.opensearch.internal
   stemcell: default
   azs: [z1]
   vm_type: t3.large
@@ -433,3 +432,17 @@ instance_groups:
   - errand-profile
   azs:
   - z1
+addons:
+- name: bosh-dns-aliases
+  jobs:
+  - name: bosh-dns-aliases
+    release: bosh-dns-aliases
+    properties:
+      aliases:
+      - domain: opensearch_dashboards.opensearch.internal
+        targets:
+        - query: '*'
+          instance_group: opensearch_dashboards
+          deployment: logs-opensearch
+          network: services
+          domain: bosh

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -344,25 +344,6 @@ instance_groups:
         as: opensearch_dashboards
         ip_addresses: true
     release: opensearch
-  - name: route_registrar
-    consumes:
-      nats-tls:
-        deployment: cf-development
-        from: nats-tls
-    properties:
-      nats:
-        tls:
-          client_cert: ((/bosh/cf-development/nats_client_cert.certificate))
-          client_key: ((/bosh/cf-development/nats_client_cert.private_key))
-          enabled: true
-      route_registrar:
-        routes:
-        - name: opensearch-dashboard
-          tls_port: 5601
-          registration_interval: 2s
-          timeout: 1s
-          server_cert_domain_san: "opensearch_dashboards.opensearch.internal"
-    release: routing
   vm_extensions:
   - 50GB_ephemeral_disk
   stemcell: default

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -345,14 +345,6 @@ instance_groups:
         as: opensearch_dashboards
         ip_addresses: true
     release: opensearch
-  - name: route_registrar
-    consumes:
-      nats-tls:
-        deployment: cf-development
-        from: nats-tls
-    release: routing
-  - name: bosh-dns-aliases
-    release: bosh-dns-aliases
   vm_extensions:
   - 50GB_ephemeral_disk
   stemcell: default

--- a/opsfiles/enable-dashboards-tls.yml
+++ b/opsfiles/enable-dashboards-tls.yml
@@ -2,6 +2,7 @@
 - type: replace
   path: /instance_groups/name=smoke-tests/jobs/name=opensearch_dashboards/properties?/opensearch_dashboards?/server?/ssl?
   value:
+    enabled: true
     certificate: ((opensearch_dashboard_web.certificate))
     private_key: ((opensearch_dashboard_web.private_key))
 
@@ -14,8 +15,10 @@
     update_mode: converge
     options:
       ca: opensearch_ca
-      common_name: opensearch_dashboards_web
-      alternative_names: ["localhost"]
+      common_name: opensearch_dashboard.web
+      alternative_names:
+      - localhost
+      - opensearch_dashboards.opensearch.internal
       extended_key_usage:
       - server_auth
       - client_auth

--- a/opsfiles/enable-dashboards-tls.yml
+++ b/opsfiles/enable-dashboards-tls.yml
@@ -1,0 +1,21 @@
+# opensearch_dashboards
+- type: replace
+  path: /instance_groups/name=smoke-tests/jobs/name=opensearch_dashboards/properties?/opensearch_dashboards?/server?/ssl?
+  value:
+    certificate: ((opensearch_dashboard_web.certificate))
+    private_key: ((opensearch_dashboard_web.private_key))
+
+# variables
+- type: replace
+  path: /variables/name=opensearch_dashboard_web?
+  value:
+    name: opensearch_dashboard_web
+    type: certificate
+    update_mode: converge
+    options:
+      ca: opensearch_ca
+      common_name: opensearch_dashboards_web
+      alternative_names: ["localhost"]
+      extended_key_usage:
+      - server_auth
+      - client_auth


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add CI job for `upload-dashboards-objects-development`
- Add job for `upload-dashboards-objects` to `maintenance` instance group
- Remove `logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov` route for dashboards. Route will be re-created later to apply to the authentication proxy running in the deployment
- Create opsfile to enable TLS for incoming requests to Opensearch Dashboards
- Add BOSH DNS alias for talking to Opensearch Dashboards from other VMs
- Refactor BOSH DNS aliases to be declared in `addons` section so they can be declared in one block

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The main security changes are:

- Enabling TLS for incoming requests to OpenSearch Dashboards, which provides more security for data in transit
- Removing route registered for Dashboards. Ultimately, this route is unnecessary since we want all users to authenticate through a proxy, so we're removing this route to avoid any direct requests to the dashboards
