### PR TITLE
fix instance group name reference in opsfile

### DIFF
--- a/opsfiles/enable-dashboards-tls.yml
+++ b/opsfiles/enable-dashboards-tls.yml
@@ -1,6 +1,6 @@
 # opensearch_dashboards
 - type: replace
-  path: /instance_groups/name=smoke-tests/jobs/name=opensearch_dashboards/properties?/opensearch_dashboards?/server?/ssl?
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=opensearch_dashboards/properties?/opensearch_dashboards?/server?/ssl?
   value:
     enabled: true
     certificate: ((opensearch_dashboard_web.certificate))


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix instance group name reference in opsfile

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The updated opsfile here is enabling TLS for requests to OpenSearch Dashboards, which previously went over HTTP, so these changes increase security
