### PR TITLE
Add auth proxy job to deployment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -113,6 +113,7 @@ jobs:
       - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
       - deploy-logs-opensearch-config/opsfiles/enable-dashboards-tls.yml
       - deploy-logs-opensearch-config/opsfiles/enable-proxy-auth.yml
+      - deploy-logs-opensearch-config/opsfiles/enable-proxy-auth-route-dev.yml
   on_failure:
     put: slack
     params: &slack-params

--- a/opsfiles/enable-auth-proxy-route-dev.yml
+++ b/opsfiles/enable-auth-proxy-route-dev.yml
@@ -1,0 +1,12 @@
+# add nats info for auth proxy route
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/properties?/nats?/tls?
+  value:
+    client_cert: ((/bosh/cf-development/nats_client_cert.certificate))
+    client_key: ((/bosh/cf-development/nats_client_cert.private_key))
+    enabled: true
+
+# add address for auth proxy route
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/properties?/route_registrar?/routes?/name=opensearch-auth-proxy/uris?/-
+  value: logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov

--- a/opsfiles/enable-proxy-auth.yml
+++ b/opsfiles/enable-proxy-auth.yml
@@ -33,3 +33,75 @@
 - type: replace
   path: /instance_groups/name=ingestor/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
   value: true
+
+# add variable for auth proxy certs
+- type: replace
+  path: /variables/name=auth_proxy?
+  value:
+    name: auth_proxy
+    options:
+      alternative_names:
+        - localhost
+        - auth-proxy.opensearch.internal
+      ca: opensearch_ca
+      common_name: auth-proxy.opensearch.internal
+      extended_key_usage:
+        - server_auth
+        - client_auth
+    type: certificate
+    update_mode: converge
+
+# add auth proxy job
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=opensearch-dashboards-cf-auth-proxy?
+  value:
+    consumes:
+      opensearch:
+        from: opensearch_manager
+        ip_addresses: true
+    name: opensearch-dashboards-cf-auth-proxy
+    properties:
+      opensearch-dashboards-cf-auth-proxy:
+        cf:
+          admin_group: ((cf-admin-group))
+          api_url: ((cf-api-url))
+        gunicorn:
+          num_workers: 4
+          timeout: 300
+        ssl:
+          ca: ((opensearch_node.ca))
+          certificate: ((auth_proxy.certificate))
+          key: ((auth_proxy.private_key))
+        opensearch_dashboards:
+          ssl:
+            ca: /var/vcap/jobs/opensearch_dashboards/config/ssl/opensearch.ca
+            certificate: /var/vcap/jobs/opensearch_dashboards/config/ssl/dashboard-web.crt
+            key: /var/vcap/jobs/opensearch_dashboards/config/ssl/dashboard-web.key
+          url: https://localhost:5601
+        port: 8000
+        secret_key: ((auth-proxy-secret-key))
+        uaa:
+          auth_url: ((uaa-auth-url))
+          base_url: ((uaa-base-url))
+          client:
+            id: ((uaa-client-id))
+            secret: ((uaa-client-secret))
+    release: opensearch
+
+# add route for auth proxy job
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar?
+  value:
+    consumes:
+      nats-tls:
+        deployment: cf-development
+        from: nats-tls
+    name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: opensearch-auth-proxy
+          registration_interval: 2s
+          server_cert_domain_san: auth-proxy.opensearch.internal
+          timeout: 1s
+          tls_port: 8000


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add auth proxy job to deployment
- Add route for auth proxy job in development

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The approach of having the CF auth proxy integrated into the BOSH deployment is preferable because:

- Makes the release completely self contained and not dependent on components deployed separately (in this case as a CF app) in order to operate
- Register the public route directly on the proxy, not on the dashboard, which would mean that the only publicly accessible URL uses the proxy and requires authentication
