### PR TITLE
update deployment to use persistent disk types

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -35,7 +35,7 @@ instance_groups:
     release: snort
   azs:
   - z1
-  persistent_disk: 10240
+  persistent_disk_type: logs_opensearch_os_master
   stemcell: default
   vm_type: t3.large
   networks:
@@ -306,7 +306,7 @@ instance_groups:
           indices.query.bool.max_clause_count: 2048
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
-  persistent_disk: 10240
+  persistent_disk_type: logs_opensearch_os_data
   stemcell: default
   azs: [z1]
   vm_type: t3.large


### PR DESCRIPTION
## Changes proposed in this pull request:

- update deployment to use persistent disk types

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just making sure our VMs have the appropriate amount of storage available
