### PR TITLE
fix opsfile name

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -113,7 +113,7 @@ jobs:
       - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
       - deploy-logs-opensearch-config/opsfiles/enable-dashboards-tls.yml
       - deploy-logs-opensearch-config/opsfiles/enable-proxy-auth.yml
-      - deploy-logs-opensearch-config/opsfiles/enable-proxy-auth-route-dev.yml
+      - deploy-logs-opensearch-config/opsfiles/enable-auth-proxy-route-dev.yml
   on_failure:
     put: slack
     params: &slack-params


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix opsfile name

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just correcting opsfile name so deployment can succeed
