### PR TITLE
update opensearch to use jammy-snort release

### DIFF
--- a/opensearch-deployment.yml
+++ b/opensearch-deployment.yml
@@ -15,7 +15,7 @@ name: logs-opensearch
 releases:
 - {name: opensearch, version: latest}
 - {name: routing, version: latest}
-- {name: snort, version: latest}
+- {name: jammy-snort, version: latest}
 - {name: bosh-dns-aliases, version: latest}
 - {name: bpm, version: latest}
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update opensearch to use jammy-snort release so we can fully deprecate bionic snort release

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Ubuntu Bionic is deprecated and Ubuntu Jammy is the current LTS version for stemcells, so we want all of our BOSH releases based on Jammy for compatibility and security
