### PR TITLE
update to cf pulling jobs to use client

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -155,13 +155,9 @@ jobs:
   - in_parallel:
     - get: pipeline-tasks
     - get: opensearch-release
-      trigger: true
-      passed: [deploy-opensearch-development]
     - get: opensearch-stemcell-jammy
-      trigger: true
-      passed: [deploy-opensearch-development]
     - get: deploy-logs-opensearch-config
-      passed: [deploy-opensearch-development]
+      passed: [tenant-development]
       trigger: true
   - task: upload-dashboards-objects
     file: pipeline-tasks/bosh-logs-errand.yml

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -17,6 +17,7 @@ instance_groups:
         as: opensearch_manager
     properties:
       opensearch:
+        dashboard_username: dashboard.opensearch.internal
         clustername: opensearch
         limits:
           fd: 131072 # 2 ** 17
@@ -102,8 +103,8 @@ instance_groups:
     properties:
       upload_tenant:
         cf:
-          username: ((cf-username-development))
-          password: ((cf-password-development))
+          client_id: opensearch_client_id
+          client_password: ((/bosh/cf-development/opensearch_client_secret))
           domain: ((cf-api-development))
     release: opensearch
   - name: opensearch_templates
@@ -175,9 +176,9 @@ instance_groups:
         event_types:
         - LogMessage
         - ContainerMetric
-        system_domain: ((system_domain))
-        user: ((dashboards_upload_user_name))
-        password: ((dashboards_upload_user_password))
+        system_domain: ((cf-api-development))
+        client_id: opensearch_client_id
+        client_password: ((/bosh/cf-development/opensearch_client_secret))
       dashboards_objects:
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-dashboards-objects/dashboards-objects/index-pattern/logs-app*.json"}

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -17,7 +17,6 @@ instance_groups:
         as: opensearch_manager
     properties:
       opensearch:
-        dashboard_username: dashboard.opensearch.internal
         clustername: opensearch
         limits:
           fd: 131072 # 2 ** 17


### PR DESCRIPTION
## Changes proposed in this pull request:

- Change cf calling jobs to use a client instead of a user
- Make upload-tenant run before upload-dashboard
-

## Security considerations

Better secure now that we use a client with the correct roles
