### PR TITLE
adding in m6i-large to stop from running out of credits

### DIFF
--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -18,11 +18,11 @@ instance_groups:
 
 - name: archiver
   instances: 1
-  vm_type: t3.medium
+  vm_type: m6i.large
 
 - name: ingestor
   instances: 1
-  vm_type: t3.medium
+  vm_type: m6i.large
 
 addons:
 - name: bosh-dns-aliases


### PR DESCRIPTION
## Changes proposed in this pull request:

- our t3 instance types for ingestor and archiver run out of credits and need to be restarted. This change allows the instance to no longer run out and need to be respun.
-
-

## Security considerations

None
