### PR TITLE
fixing the instance type so it doesn't fall for opensearch_data

### DIFF
--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -7,7 +7,7 @@ instance_groups:
 
 - name: opensearch_data
   instances: 3
-  vm_type: t3.large
+  vm_type: m6i.large
   update:
     max_in_flight: 2
     canaries: 2


### PR DESCRIPTION
## Changes proposed in this pull request:
- updating instance type for opensearch_data so it doesn't enter scan and fix as often
- 
-

## Things to check

- We might want to switch all opensearch vms to m6i. opensearch_manager and dashboard are not above 50 on average
- 
## Security considerations

None
