### PR TITLE
fixing order for smoketests and adding missing piece of ingestor

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -190,12 +190,12 @@ jobs:
     - get: pipeline-tasks
     - get: opensearch-release
       trigger: true
-      passed: [deploy-opensearch-development]
+      passed: [upload-dashboards-objects-development]
     - get: opensearch-stemcell-jammy
       trigger: true
-      passed: [deploy-opensearch-development]
+      passed: [upload-dashboards-objects-development]
     - get: deploy-logs-opensearch-config
-      passed: [deploy-opensearch-development]
+      passed: [upload-dashboards-objects-development]
       trigger: true
   - task: smoke-tests
     file: pipeline-tasks/bosh-logs-errand.yml
@@ -412,12 +412,12 @@ jobs:
     - get: pipeline-tasks
     - get: opensearch-release
       trigger: true
-      passed: [deploy-opensearch-staging]
+      passed: [upload-dashboards-objects-staging]
     - get: opensearch-stemcell-jammy
       trigger: true
-      passed: [deploy-opensearch-staging]
+      passed: [upload-dashboards-objects-staging]
     - get: deploy-logs-opensearch-config
-      passed: [deploy-opensearch-staging]
+      passed: [upload-dashboards-objects-staging]
       trigger: true
   - task: smoke-tests
     file: pipeline-tasks/bosh-logs-errand.yml

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -297,6 +297,9 @@ instance_groups:
   stemcell: default
   azs: [z1]
   vm_type: t3.medium
+  vm_extensions:
+  - logs-opensearch-ingestor-profile
+  - 50GB_ephemeral_disk
   networks:
   - name: services
 


### PR DESCRIPTION
## Changes proposed in this pull request: 
- Change order so tenant gets recreated before smoke-test is ran
- Fix ingesor missing extensions for emphereal disk so it wont run out
-

## Security considerations

None
