### PR TITLE
remove duplicate ingestor definitions

### DIFF
--- a/prod-logsearch-ingestors.yml
+++ b/prod-logsearch-ingestors.yml
@@ -77,16 +77,7 @@ instance_groups:
   name: ingestor_logsearch_august_1
 
 - <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_august_1
-
-- <<: *logsearch-ingestor-config
   name: ingestor_logsearch_august_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_august_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_july_1
 
 - <<: *logsearch-ingestor-config
   name: ingestor_logsearch_july_1


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
