### PR TITLE
Fix opsfiles

### DIFF
--- a/opsfiles/add-prod-logsearch-ingestors.yml
+++ b/opsfiles/add-prod-logsearch-ingestors.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/-
   value:
     options:
       bucket: logsearch-cf-production

--- a/opsfiles/add-prod-logsearch-ingestors.yml
+++ b/opsfiles/add-prod-logsearch-ingestors.yml
@@ -1,247 +1,247 @@
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/28
-    plugin: s3
-  
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/27
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/26
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/25
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/24
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/24
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/22
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/21
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/20
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/19
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/18
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/17
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/16
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/14
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/13
-    plugin: s3
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-  value:
-    options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
-      type: syslog
-      prefix: 2024/03/12
-    plugin: s3
-
-- type: replace
   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/11
+      prefix: 2024/03/04
     plugin: s3
-
+  
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=ingestor_logsearch/properties/logstash_parser?/inputs?/0
+  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/10
+      prefix: 2024/03/03
     plugin: s3
 
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/09
+      prefix: 2024/03/02
     plugin: s3
 
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/08
+      prefix: 2024/02/29
     plugin: s3
 
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/07
+      prefix: 2024/02/28
     plugin: s3
 
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/06
+      prefix: 2024/02/27
     plugin: s3
 
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
-      bucket: logsearch-cf-production
-      region: us-gov-west-1
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
       type: syslog
-      prefix: 2024/03/05
+      prefix: 2024/02/26
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_8?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/25
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_9?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/24
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_10?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/23
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_11?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/22
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_12?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/21
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_13?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/20
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_14?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/19
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_15?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/18
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_16?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/17
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_17?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/16
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_18?/jobs/name=ingestor_logsearch/properties/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/14
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_19?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/13
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_20?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/12
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_21?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/11
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_22?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/10
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_23?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: ((logsearch_archive_bucket_name))
+      region: ((vpc_region))
+      type: syslog
+      prefix: 2024/02/09
     plugin: s3
 
 # ingestor_logsearch
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
   value: 127.0.0.1
 
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/admin?
   value: &admin-tls-properties
     dn: CN=admin.opensearch.internal
     certificate: ((opensearch_admin.certificate))
     private_key: ((opensearch_admin.private_key))
 
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
   value: &node-tls-properties
     dn:
       - "CN=node.opensearch.internal"
@@ -251,317 +251,11 @@
     private_key: ((opensearch_node.private_key))
 
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
   value: &http-tls-properties
     ca: ((opensearch_node.ca))
     certificate: ((opensearch_node.certificate))
     private_key: ((opensearch_node.private_key))
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
 
 # ingestor_logsearch
 - type: replace
@@ -580,7 +274,7 @@
   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
   value: *http-tls-properties
 
-  # ingestor_logsearch
+# ingestor_logsearch
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http_host?
   value: 127.0.0.1
@@ -663,4 +357,276 @@
 
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_8?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_8?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_8?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_8?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_9?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_9?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_9?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_9?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_10?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_10?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_10?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_10?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_11?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_11?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_11?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_11?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_12?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_12?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_12?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_12?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_13?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_13?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_13?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_13?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_14?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_14?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_14?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_14?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_15?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_15?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_15?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_15?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_16?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_16?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_16?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_16?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_17?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_17?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_17?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_17?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_18?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_18?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_18?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_18?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_19?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_19?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_19?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_19?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_20?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_20?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_20?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_20?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_21?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_21?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_21?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_21?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_22?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_22?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_22?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_22?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_23?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_23?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_23?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_23?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
   value: *http-tls-properties

--- a/opsfiles/add-prod-logsearch-ingestors.yml
+++ b/opsfiles/add-prod-logsearch-ingestors.yml
@@ -8,527 +8,533 @@
       prefix: 2024/03/28
     plugin: s3
   
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/27
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/26
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/25
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/24
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/23
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/22
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/21
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/20
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/19
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/18
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/17
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/16
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/14
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/13
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/12
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/11
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=ingestor_logsearch/properties/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/10
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/09
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/08
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/07
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/06
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/05
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: &admin-tls-properties
-    dn: CN=admin.opensearch.internal
-    certificate: ((opensearch_admin.certificate))
-    private_key: ((opensearch_admin.private_key))
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: &node-tls-properties
-    dn:
-      - "CN=node.opensearch.internal"
-      - "CN=dashboard.opensearch.internal"
-    ca: ((opensearch_node.ca))
-    certificate: ((opensearch_node.certificate))
-    private_key: ((opensearch_node.private_key))
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: &http-tls-properties
-    ca: ((opensearch_node.ca))
-    certificate: ((opensearch_node.certificate))
-    private_key: ((opensearch_node.private_key))
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-  # ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
-
-# ingestor_logsearch
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http_host?
-  value: 127.0.0.1
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/admin?
-  value: *admin-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-  value: *node-tls-properties
-
-- type: replace
-  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-  value: *http-tls-properties
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+#   value:
+#     options:
+#       bucket: logsearch-cf-production
+#       region: us-gov-west-1
+#       type: syslog
+#       prefix: 2024/03/27
+#     plugin: s3
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/26
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/25
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/24
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/23
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/22
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/21
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/20
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/19
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/18
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/17
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/16
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/14
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/13
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/12
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/11
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=ingestor_logsearch/properties/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/10
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/09
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/08
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/07
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/06
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
+#   value: 2024/03/05
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: &admin-tls-properties
+#     dn: CN=admin.opensearch.internal
+#     certificate: ((opensearch_admin.certificate))
+#     private_key: ((opensearch_admin.private_key))
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: &node-tls-properties
+#     dn:
+#       - "CN=node.opensearch.internal"
+#       - "CN=dashboard.opensearch.internal"
+#     ca: ((opensearch_node.ca))
+#     certificate: ((opensearch_node.certificate))
+#     private_key: ((opensearch_node.private_key))
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: &http-tls-properties
+#     ca: ((opensearch_node.ca))
+#     certificate: ((opensearch_node.certificate))
+#     private_key: ((opensearch_node.private_key))
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+#   # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties
+
+# # ingestor_logsearch
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http_host?
+#   value: 127.0.0.1
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/admin?
+#   value: *admin-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+#   value: *node-tls-properties
+
+# - type: replace
+#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+#   value: *http-tls-properties

--- a/opsfiles/add-prod-logsearch-ingestors.yml
+++ b/opsfiles/add-prod-logsearch-ingestors.yml
@@ -8,533 +8,659 @@
       prefix: 2024/03/28
     plugin: s3
   
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
-#   value:
-#     options:
-#       bucket: logsearch-cf-production
-#       region: us-gov-west-1
-#       type: syslog
-#       prefix: 2024/03/27
-#     plugin: s3
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/26
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/25
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/24
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/23
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/22
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/21
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/20
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/19
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/18
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/17
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/16
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/14
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/13
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/12
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/11
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=ingestor_logsearch/properties/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/10
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/09
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/08
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/07
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/06
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-#   value: 2024/03/05
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: &admin-tls-properties
-#     dn: CN=admin.opensearch.internal
-#     certificate: ((opensearch_admin.certificate))
-#     private_key: ((opensearch_admin.private_key))
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: &node-tls-properties
-#     dn:
-#       - "CN=node.opensearch.internal"
-#       - "CN=dashboard.opensearch.internal"
-#     ca: ((opensearch_node.ca))
-#     certificate: ((opensearch_node.certificate))
-#     private_key: ((opensearch_node.private_key))
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: &http-tls-properties
-#     ca: ((opensearch_node.ca))
-#     certificate: ((opensearch_node.certificate))
-#     private_key: ((opensearch_node.private_key))
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-#   # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
-
-# # ingestor_logsearch
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http_host?
-#   value: 127.0.0.1
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/admin?
-#   value: *admin-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
-#   value: *node-tls-properties
-
-# - type: replace
-#   path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
-#   value: *http-tls-properties
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/27
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/26
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/25
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/24
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/24
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/22
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/21
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/20
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/19
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/18
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/17
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/16
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/14
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/13
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/12
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/11
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=ingestor_logsearch/properties/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/10
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/09
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/08
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/07
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/06
+    plugin: s3
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/05
+    plugin: s3
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: &admin-tls-properties
+    dn: CN=admin.opensearch.internal
+    certificate: ((opensearch_admin.certificate))
+    private_key: ((opensearch_admin.private_key))
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: &node-tls-properties
+    dn:
+      - "CN=node.opensearch.internal"
+      - "CN=dashboard.opensearch.internal"
+    ca: ((opensearch_node.ca))
+    certificate: ((opensearch_node.certificate))
+    private_key: ((opensearch_node.private_key))
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: &http-tls-properties
+    ca: ((opensearch_node.ca))
+    certificate: ((opensearch_node.certificate))
+    private_key: ((opensearch_node.private_key))
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_august_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_july_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_june_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_may_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_april_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_march_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_february_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_january_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_1?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_2?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+  # ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_3?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_4?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_5?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_6?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+# ingestor_logsearch
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_logsearch_7?/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties

--- a/opsfiles/add-prod-logsearch-ingestors.yml
+++ b/opsfiles/add-prod-logsearch-ingestors.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/-
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0
   value:
     options:
       bucket: logsearch-cf-production

--- a/opsfiles/add-prod-logsearch-ingestors.yml
+++ b/opsfiles/add-prod-logsearch-ingestors.yml
@@ -1,7 +1,13 @@
 - type: replace
-  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
-  value: 2024/03/28
-
+  path: /instance_groups/name=ingestor_logsearch_september_1?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?
+  value:
+    options:
+      bucket: logsearch-cf-production
+      region: us-gov-west-1
+      type: syslog
+      prefix: 2024/03/28
+    plugin: s3
+  
 - type: replace
   path: /instance_groups/name=ingestor_logsearch_september_2?/jobs/name=ingestor_logsearch/properties?/logstash_parser?/inputs?/0?/options?/prefix?
   value: 2024/03/27

--- a/prod-logsearch-ingestors.yml
+++ b/prod-logsearch-ingestors.yml
@@ -1,6 +1,6 @@
 instance_groups:
 - &logsearch-ingestor-config
-  name: ingestor_logsearch_september_1
+  name: ingestor_logsearch_1
   instances: 1
   jobs:
   - name: bpm
@@ -71,60 +71,6 @@ instance_groups:
   - 50GB_ephemeral_disk
 
 - <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_september_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_august_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_august_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_july_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_july_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_june_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_june_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_may_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_may_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_april_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_april_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_march_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_march_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_february_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_february_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_january_1
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_january_2
-
-- <<: *logsearch-ingestor-config
-  name: ingestor_logsearch_1
-
-- <<: *logsearch-ingestor-config
   name: ingestor_logsearch_2
 
 - <<: *logsearch-ingestor-config
@@ -141,3 +87,51 @@ instance_groups:
 
 - <<: *logsearch-ingestor-config
   name: ingestor_logsearch_7
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_8
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_9
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_10
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_11
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_12
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_13
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_14
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_15
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_16
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_17
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_18
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_19
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_20
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_21
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_22
+
+- <<: *logsearch-ingestor-config
+  name: ingestor_logsearch_23

--- a/varsfiles/terraform.yml
+++ b/varsfiles/terraform.yml
@@ -1,2 +1,4 @@
 redis_host: ((terraform_outputs.opensearch_proxy_redis_cluster.host))
 redis_password: ((terraform_outputs.opensearch_proxy_redis_cluster.password))
+logsearch_archive_bucket_name: ((terraform_outputs.logsearch_archive_bucket_name))
+vpc_region: ((terraform_outputs.vpc_region))


### PR DESCRIPTION
## Changes proposed in this pull request:

- Rename logsearch ingestor instance groups
- Update dates for logsearch ingestor VMs
- Fix opsfile syntax

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just refactoring code and updating logsearch ingestor VMs
