### PR TITLE
remove smoke tests job in prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -553,6 +553,7 @@ jobs:
       - opensearch-stemcell-jammy/*.tgz
       ops_files:
       - deploy-logs-opensearch-config/opsfiles/remove-curator.yml
+      - deploy-logs-opensearch-config/opsfiles/remove-smoke-tests.yml
       - deploy-logs-opensearch-config/opsfiles/add-prod-logsearch-ingestors.yml
       - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
       - deploy-logs-opensearch-config/opsfiles/enable-dashboard-dns.yml

--- a/opsfiles/remove-smoke-tests.yml
+++ b/opsfiles/remove-smoke-tests.yml
@@ -1,0 +1,2 @@
+- type: remove
+  path: /instance_groups/name=maintenance/jobs/name=smoke_tests


### PR DESCRIPTION
## Changes proposed in this pull request:

-
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None