### PR TITLE
refactor opsfiles for registering auth proxy route 

### DIFF
--- a/opsfiles/enable-auth-proxy-route-dev.yml
+++ b/opsfiles/enable-auth-proxy-route-dev.yml
@@ -10,3 +10,7 @@
 - type: replace
   path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/properties?/route_registrar?/routes?/name=opensearch-auth-proxy/uris?/-
   value: logs-beta.dev.us-gov-west-1.aws-us-gov.cloud.gov
+
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/consumes?/nats-tls?/deployment?
+  value: cf-development

--- a/opsfiles/enable-auth-proxy-route-production.yml
+++ b/opsfiles/enable-auth-proxy-route-production.yml
@@ -10,3 +10,7 @@
 - type: replace
   path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/properties?/route_registrar?/routes?/name=opensearch-auth-proxy/uris?/-
   value: logs-beta.fr.cloud.gov
+
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/consumes?/nats-tls?/deployment?
+  value: cf-production

--- a/opsfiles/enable-auth-proxy-route-staging.yml
+++ b/opsfiles/enable-auth-proxy-route-staging.yml
@@ -10,3 +10,7 @@
 - type: replace
   path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/properties?/route_registrar?/routes?/name=opensearch-auth-proxy/uris?/-
   value: logs-beta.fr-stage.cloud.gov
+
+- type: replace
+  path: /instance_groups/name=opensearch_dashboards/jobs/name=route_registrar/consumes?/nats-tls?/deployment?
+  value: cf-staging

--- a/opsfiles/enable-proxy-auth.yml
+++ b/opsfiles/enable-proxy-auth.yml
@@ -98,7 +98,6 @@
   value:
     consumes:
       nats-tls:
-        deployment: ((cf-deployment))
         from: nats-tls
     name: route_registrar
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- refactor opsfiles for registering auth proxy route to use static value e for nats-tls deployment value

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, should just fix an issue where BOSH is always detecting a change even when nothing has changed
