### PR TITLE
turning off until replicas is done

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -503,13 +503,13 @@ jobs:
     - get: pipeline-tasks
     - get: deploy-logs-opensearch-config
       trigger: true
-      #passed: [smoke-tests-staging]
+      passed: [smoke-tests-staging]
     - get: opensearch-release
       trigger: true
-      #passed: [smoke-tests-staging]
+      passed: [smoke-tests-staging]
     - get: opensearch-stemcell-jammy
       trigger: true
-      #passed: [smoke-tests-staging]
+      passed: [smoke-tests-staging]
     - get: terraform-yaml
       resource: terraform-yaml-production
       trigger: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -503,13 +503,13 @@ jobs:
     - get: pipeline-tasks
     - get: deploy-logs-opensearch-config
       trigger: true
-      passed: [smoke-tests-staging]
+      #passed: [smoke-tests-staging]
     - get: opensearch-release
       trigger: true
-      passed: [smoke-tests-staging]
+      #passed: [smoke-tests-staging]
     - get: opensearch-stemcell-jammy
       trigger: true
-      passed: [smoke-tests-staging]
+      #passed: [smoke-tests-staging]
     - get: terraform-yaml
       resource: terraform-yaml-production
       trigger: true
@@ -775,7 +775,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: https://github.com/cloud-gov/cg-deploy-opensearch.git
-    branch: main
+    branch: partial
 
 - name: opensearch-stemcell-jammy
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -775,7 +775,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: https://github.com/cloud-gov/cg-deploy-opensearch.git
-    branch: partial
+    branch: main
 
 - name: opensearch-stemcell-jammy
   source:

--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -24,6 +24,9 @@ instance_groups:
   instances: 1
   vm_type: m6i.large
 
+- name: ingestor_cloudwatch
+  instances: 1
+
 - name: maintenance
   vm_type: t3.large
   instances: 1

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -427,7 +427,7 @@ instance_groups:
   persistent_disk_type: logs_opensearch_ingestor
   stemcell: default
   azs: [z1]
-  vm_type: t3.medium
+  vm_type: m6i.large
   vm_extensions:
   - logs-opensearch-ingestor-profile
   - 15GB_ephemeral_disk

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -377,3 +377,59 @@ instance_groups:
   - 15GB_ephemeral_disk
   networks:
   - name: services
+
+- name: ingestor_cloudwatch
+  instances: 1
+  jobs:
+  - name: bpm
+    release: bpm
+  - name: opensearch
+    release: opensearch
+    consumes: *consumes-opensearch-manager
+    properties:
+      opensearch:
+        heap_size: 1G
+        http_host: 127.0.0.1
+        jvm_options:
+        - -Dlog4j2.formatMsgNoLookups=true
+  - consumes: *consumes-opensearch-manager
+    name: ingestor_cloudwatch
+    properties:
+      logstash:
+        jvm_options:
+        - -Dlog4j2.formatMsgNoLookups=true
+        queue:
+          max_bytes: 30gb
+      logstash_ingestor:
+        cloudwatch:
+          region: ((region))
+          prefix: ((cloudwatch_prefix))
+        syslog_tls:
+          port: 6972
+          ssl_cert: ((ingestor_syslog_server_tls.certificate))
+          ssl_key: ((ingestor_syslog_server_tls.private_key))
+      logstash_parser:
+        opensearch:
+          data_hosts:
+          - localhost
+          index: ((alias))
+          index_type: '%{@type}'
+          ssl:
+            ca: ((opensearch_node.ca))
+            certificate: ((logstash.certificate))
+            private_key: ((logstash.private_key))
+    provides:
+      ingestor:
+        as: ingestor_cloudwtch
+    release: opensearch
+  - name: deployment_lookup_config
+    release: opensearch
+  persistent_disk_type: logs_opensearch_ingestor
+  stemcell: default
+  azs: [z1]
+  vm_type: t3.medium
+  vm_extensions:
+  - logs-opensearch-ingestor-profile
+  - 15GB_ephemeral_disk
+  networks:
+  - name: services

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -334,36 +334,6 @@ instance_groups:
         http_host: 127.0.0.1
         jvm_options:
         - -Dlog4j2.formatMsgNoLookups=true
-  - consumes: *consumes-opensearch-manager
-    name: ingestor_cloudwatch
-    properties:
-      logstash:
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
-        queue:
-          max_bytes: 30gb
-      logstash_ingestor:
-        cloudwatch:
-          region: ((region))
-          prefix: ((cloudwatch_prefix))
-        syslog_tls:
-          port: 6972
-          ssl_cert: ((ingestor_syslog_server_tls.certificate))
-          ssl_key: ((ingestor_syslog_server_tls.private_key))
-      logstash_parser:
-        opensearch:
-          data_hosts:
-          - localhost
-          index: ((alias))
-          index_type: '%{@type}'
-          ssl:
-            ca: ((opensearch_node.ca))
-            certificate: ((logstash.certificate))
-            private_key: ((logstash.private_key))
-    provides:
-      ingestor:
-        as: ingestor_cloudwtch
-    release: opensearch
   - name: ingestor_syslog
     consumes: *consumes-opensearch-manager
     properties:

--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -27,6 +27,10 @@ instance_groups:
   instances: 7
   vm_type: r6i.xlarge.logsearch.ingestor
 
+- name: ingestor_cloudwatch
+  instances: 1
+  vm_type: r6i.large.logsearch.ingestor
+
 - name: maintenance
   vm_type: t3.large
   instances: 1

--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -24,7 +24,7 @@ instance_groups:
   vm_type: r6i.large
 
 - name: ingestor
-  instances: 0
+  instances: 7
   vm_type: r6i.xlarge.logsearch.ingestor
 
 - name: maintenance

--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -24,7 +24,7 @@ instance_groups:
   vm_type: r6i.large
 
 - name: ingestor
-  instances: 7
+  instances: 0
   vm_type: r6i.xlarge.logsearch.ingestor
 
 - name: maintenance

--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -29,7 +29,6 @@ instance_groups:
 
 - name: ingestor_cloudwatch
   instances: 1
-  vm_type: r6i.large.logsearch.ingestor
 
 - name: maintenance
   vm_type: t3.large

--- a/opensearch-staging.yml
+++ b/opensearch-staging.yml
@@ -27,6 +27,9 @@ instance_groups:
   instances: 1
   vm_type: m6i.large
 
+- name: ingestor_cloudwatch
+  instances: 1
+
 - name: maintenance
   vm_type: t3.large
   instances: 1

--- a/opsfiles/enable-node-tls.yml
+++ b/opsfiles/enable-node-tls.yml
@@ -123,6 +123,24 @@
   path: /instance_groups/name=ingestor/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
   value: *http-tls-properties
 
+# ingestor_cloudwatch
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties?/opensearch?/http_host?
+  value: 127.0.0.1
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties/opensearch?/admin?
+  value: *admin-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  value: *node-tls-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  value: *http-tls-properties
+
+
 # smoke_tests
 # - type: replace
 #   path: /instance_groups/name=maintenance/jobs/name=smoke_tests/properties?/smoke_tests?/opensearch?/ssl?

--- a/opsfiles/enable-proxy-auth.yml
+++ b/opsfiles/enable-proxy-auth.yml
@@ -33,7 +33,10 @@
 - type: replace
   path: /instance_groups/name=ingestor/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
   value: true
-
+# ingestor_cloudwatch
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
+  value: true
 # add variable for auth proxy certs
 - type: replace
   path: /variables/name=auth_proxy?


### PR DESCRIPTION
## Changes proposed in this pull request:

- quick turn off
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations
None
