### PR TITLE
Bump instance types dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv
+__pycache__

--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -1,13 +1,13 @@
 instance_groups:
 - name: opensearch_manager
-  vm_type: t3.medium
+  vm_type: t3.large
   instances: 1
   networks:
   - name: services
 
 - name: opensearch_data
   instances: 3
-  vm_type: m6i.large
+  vm_type: r6i.large
   update:
     max_in_flight: 2
     canaries: 2
@@ -18,7 +18,7 @@ instance_groups:
 
 - name: archiver
   instances: 1
-  vm_type: m6i.large
+  vm_type: m6i.xlarge
 
 - name: ingestor
   instances: 1


### PR DESCRIPTION
## Changes proposed in this pull request:

- bump some instance types for dev based on VMs getting close to memory limits

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
