### PR TITLE
update instance group name for ingesting RDS cloudwatch logs

### DIFF
--- a/opensearch-development.yml
+++ b/opensearch-development.yml
@@ -24,7 +24,7 @@ instance_groups:
   instances: 1
   vm_type: m6i.large
 
-- name: ingestor_cloudwatch
+- name: ingestor_cloudwatch_rds
   instances: 1
 
 - name: maintenance

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -403,7 +403,7 @@ instance_groups:
       logstash_ingestor:
         cloudwatch:
           region: ((region))
-          prefix: ((cloudwatch_prefix))
+          prefix: ((rds_cloudwatch_prefix))
         syslog_tls:
           port: 6972
           ssl_cert: ((ingestor_syslog_server_tls.certificate))

--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -378,7 +378,7 @@ instance_groups:
   networks:
   - name: services
 
-- name: ingestor_cloudwatch
+- name: ingestor_cloudwatch_rds
   instances: 1
   jobs:
   - name: bpm

--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -27,7 +27,7 @@ instance_groups:
   instances: 7
   vm_type: r6i.xlarge.logsearch.ingestor
 
-- name: ingestor_cloudwatch
+- name: ingestor_cloudwatch_rds
   instances: 1
   vm_type: r6i.large
 

--- a/opensearch-staging.yml
+++ b/opensearch-staging.yml
@@ -27,7 +27,7 @@ instance_groups:
   instances: 1
   vm_type: m6i.large
 
-- name: ingestor_cloudwatch
+- name: ingestor_cloudwatch_rds
   instances: 1
 
 - name: maintenance

--- a/opsfiles/enable-node-tls.yml
+++ b/opsfiles/enable-node-tls.yml
@@ -123,21 +123,21 @@
   path: /instance_groups/name=ingestor/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
   value: *http-tls-properties
 
-# ingestor_cloudwatch
+# ingestor_cloudwatch_rds
 - type: replace
-  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties?/opensearch?/http_host?
+  path: /instance_groups/name=ingestor_cloudwatch_rds/jobs/name=opensearch/properties?/opensearch?/http_host?
   value: 127.0.0.1
 
 - type: replace
-  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties/opensearch?/admin?
+  path: /instance_groups/name=ingestor_cloudwatch_rds/jobs/name=opensearch/properties/opensearch?/admin?
   value: *admin-tls-properties
 
 - type: replace
-  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties/opensearch?/node?/ssl?
+  path: /instance_groups/name=ingestor_cloudwatch_rds/jobs/name=opensearch/properties/opensearch?/node?/ssl?
   value: *node-tls-properties
 
 - type: replace
-  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
+  path: /instance_groups/name=ingestor_cloudwatch_rds/jobs/name=opensearch/properties?/opensearch?/http?/ssl?
   value: *http-tls-properties
 
 

--- a/opsfiles/enable-proxy-auth.yml
+++ b/opsfiles/enable-proxy-auth.yml
@@ -33,9 +33,9 @@
 - type: replace
   path: /instance_groups/name=ingestor/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
   value: true
-# ingestor_cloudwatch
+# ingestor_cloudwatch_rds
 - type: replace
-  path: /instance_groups/name=ingestor_cloudwatch/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
+  path: /instance_groups/name=ingestor_cloudwatch_rds/jobs/name=opensearch/properties?/opensearch?/enable_proxy_auth
   value: true
 # add variable for auth proxy certs
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:

- update instance group name for ingesting RDS cloudwatch logs to make the purpose of the instance group more clear, since it will only be used for ingesting RDS logs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just renaming
