### PR TITLE
increase number of ingestors in prod to 9

### DIFF
--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -24,7 +24,7 @@ instance_groups:
   vm_type: r6i.large
 
 - name: ingestor
-  instances: 7
+  instances: 9
   vm_type: r6i.xlarge.logsearch.ingestor
 
 - name: ingestor_cloudwatch_rds


### PR DESCRIPTION
## Changes proposed in this pull request:

- increase number of ingestors in prod to 9 to keep up with incoming logs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just scaling up resources to handle load
