### PR TITLE
add CF client configuration for opensearch job on data nodes

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -26,6 +26,8 @@ instance_groups:
           indices.query.bool.max_clause_count: 2048
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
+        cf:
+          client_id: opensearch_client_id
   persistent_disk_type: logs_opensearch_os_data
   stemcell: default
   azs: [z1]

--- a/opsfiles/cf-development.yml
+++ b/opsfiles/cf-development.yml
@@ -13,3 +13,9 @@
   path: /instance_groups/name=maintenance/jobs/name=upload-dashboards-objects/properties?/cloudfoundry?/system_domain?
   value: ((cf-api-development))
 
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties?/opensearch?/cf?/client_password?
+  value: ((/bosh/cf-development/opensearch_client_secret))
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties?/opensearch?/cf?/domain?
+  value: ((cf-api-development))

--- a/opsfiles/cf-production.yml
+++ b/opsfiles/cf-production.yml
@@ -12,3 +12,10 @@
 - type: replace
   path: /instance_groups/name=maintenance/jobs/name=upload-dashboards-objects/properties?/cloudfoundry?/system_domain?
   value: ((cf-api-production))
+
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties?/opensearch?/cf?/client_password?
+  value: ((/bosh/cf-production/opensearch_client_secret))
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties?/opensearch?/cf?/domain?
+  value: ((cf-api-production))

--- a/opsfiles/cf-staging.yml
+++ b/opsfiles/cf-staging.yml
@@ -12,3 +12,11 @@
 - type: replace
   path: /instance_groups/name=maintenance/jobs/name=upload-dashboards-objects/properties?/cloudfoundry?/system_domain?
   value: ((cf-api-staging))
+
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties?/opensearch?/cf?/client_password?
+  value: ((/bosh/cf-staging/opensearch_client_secret))
+- type: replace
+  path: /instance_groups/name=opensearch_data/jobs/name=opensearch/properties?/opensearch?/cf?/domain?
+  value: ((cf-api-staging))
+


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/opensearch-boshrelease/issues/150
Related to https://github.com/cloud-gov/opensearch-boshrelease/pull/155

- Add CF client configuration for opensearch job on data nodes so it can prepare tenant, role, and role mapping configuration for CF orgs

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. We are not adding new roles or permissions, just ensuring that tenants and roles for CF orgs are not destroyed on restart of opensearch nodes
