### PR TITLE
CI related improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .pytest_cache
 test-results
 venv
+ci-test-results

--- a/README.md
+++ b/README.md
@@ -20,9 +20,34 @@ properties:
 
 ## e2e tests with Playwright
 
-This code includes e2e tests for logging into OpenSearch that use Python Playwright. To run these tests:
+This project includes e2e tests for logging into OpenSearch that use Python Playwright. To run these tests:
 
 ```shell
 cp .env-sample .env # Update values in .env afterwards
 ./scripts/e2e-local.sh
 ```
+
+## Downloading test results from CI
+
+When the e2e tests run in CI, traces from failed test runs may be created. To download these traces, use the provided script:
+
+```shell
+./scripts/download-e2e-ci-results.sh <BUILD_NUMBER> [ENVIRONMENT]
+```
+
+where:
+
+- `BUILD_NUMBER` - the number of the failed `smoke-tests-login-<environment>` job from the pipeline
+- `ENVIRONMENT` - **optionally** specify the environment for the tests: `development`, `staging`, or `production`. defaults to `production`.
+
+To view downloaded trace files:
+
+```shell
+source venv/bin/activate
+pip install -r ci/requirements.txt
+playwright show-trace ci-test-results/<dir>/trace.zip
+```
+
+where `<dir>` is an abitrary directory name generated for the test run by Playwright.
+
+See <https://playwright.dev/python/docs/trace-viewer> for more information about working with Playwright traces.

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,6 +20,11 @@ groups:
     - smoke-tests-production
     - smoke-tests-login-production
     - tenant-production
+  - name: update-test-users
+    jobs:
+    - update-test-users-dev
+    - update-test-users-staging
+    - update-test-users-production
   - name: development
     jobs:
     - deploy-opensearch-development
@@ -118,41 +123,107 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
-# - name: update-test-users-dev
-#   serial: true
-#   plan:
-#   - get: deploy-logs-opensearch-config
-#     params: {depth: 1}
-#   - get: master-bosh-root-cert
-#   - get: general-task
-#   - get: weekly
-#     trigger: true
-#   - task: update-test-user-credentials
-#     image: general-task
-#     config:
-#       inputs:
-#         - name: deploy-logs-opensearch-config
-#         - name: master-bosh-root-cert
-#       platform: linux
-#       run:
-#         path: deploy-logs-opensearch-config/ci/update-test-user-passwords.sh
-#       params:
-#         BOSH_DIRECTOR_NAME: development
-#         UAA_API_URL: ((uaa-url-development))
-#         UAA_CLIENT_ID: ((uaa-client-id-development))
-#         UAA_CLIENT_SECRET: ((uaa-client-secret-development))
-#         TEST_USERS_CREDENTIAL_USERNAME_MAP: ((dev-test-users-credential-username-map))
-#         CREDHUB_CA_CERT: master-bosh-root-cert/((master-bosh-cert-file))
-#         CREDHUB_CLIENT: ((opensearch-ci-credhub-client-id))
-#         CREDHUB_SECRET: ((opensearch-ci-credhub-client-secret))
-#         CREDHUB_SERVER: ((credhub-api-server))
-#   on_failure:
-#     put: slack
-#     params: 
-#       <<: *slack-failure-params
-#       text: |
-#         :x: Failed to update test users
-#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+- name: update-test-users-dev
+  serial: true
+  plan:
+  - get: deploy-logs-opensearch-config
+    params: {depth: 1}
+  - get: general-task
+  - get: weekly
+    trigger: true
+  - task: update-test-user-credentials
+    image: general-task
+    config:
+      inputs:
+        - name: deploy-logs-opensearch-config
+      platform: linux
+      run:
+        path: deploy-logs-opensearch-config/ci/update-test-user-passwords.sh
+      params:
+        BOSH_DIRECTOR_NAME: development
+        UAA_API_URL: ((uaa-url-development))
+        UAA_CLIENT_ID: ((uaa-client-id-development))
+        UAA_CLIENT_SECRET: ((uaa-client-secret-development))
+        TEST_USERS_CREDENTIAL_USERNAME_MAP: ((dev-test-users-credential-username-map))
+        CREDHUB_CA_CERT: ((master-bosh-ca.certificate))
+        CREDHUB_CLIENT: ((opensearch-ci-credhub-client-id))
+        CREDHUB_SECRET: ((opensearch-ci-credhub-client-secret))
+        CREDHUB_SERVER: ((credhub-api-server))
+  on_failure:
+    put: slack
+    params: 
+      <<: *slack-failure-params
+      text: |
+        :x: Failed to update test users
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: update-test-users-staging
+  serial: true
+  plan:
+  - get: deploy-logs-opensearch-config
+    params: {depth: 1}
+  - get: general-task
+  - get: weekly
+    trigger: true
+  - task: update-test-user-credentials
+    image: general-task
+    config:
+      inputs:
+        - name: deploy-logs-opensearch-config
+      platform: linux
+      run:
+        path: deploy-logs-opensearch-config/ci/update-test-user-passwords.sh
+      params:
+        BOSH_DIRECTOR_NAME: staging
+        UAA_API_URL: ((uaa-url-staging))
+        UAA_CLIENT_ID: ((uaa-client-id-staging))
+        UAA_CLIENT_SECRET: ((uaa-client-secret-staging))
+        TEST_USERS_CREDENTIAL_USERNAME_MAP: ((staging-test-users-credential-username-map))
+        CREDHUB_CA_CERT: ((master-bosh-ca.certificate))
+        CREDHUB_CLIENT: ((opensearch-ci-credhub-client-id))
+        CREDHUB_SECRET: ((opensearch-ci-credhub-client-secret))
+        CREDHUB_SERVER: ((credhub-api-server))
+  on_failure:
+    put: slack
+    params: 
+      <<: *slack-failure-params
+      text: |
+        :x: Failed to update test users
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: update-test-users-production
+  serial: true
+  plan:
+  - get: deploy-logs-opensearch-config
+    params: {depth: 1}
+  - get: general-task
+  - get: weekly
+    trigger: true
+  - task: update-test-user-credentials
+    image: general-task
+    config:
+      inputs:
+        - name: deploy-logs-opensearch-config
+      platform: linux
+      run:
+        path: deploy-logs-opensearch-config/ci/update-test-user-passwords.sh
+      params:
+        BOSH_DIRECTOR_NAME: production
+        UAA_API_URL: ((uaa-url-production))
+        UAA_CLIENT_ID: ((uaa-client-id-production))
+        UAA_CLIENT_SECRET: ((uaa-client-secret-production))
+        TEST_USERS_CREDENTIAL_USERNAME_MAP: ((production-test-users-credential-username-map))
+        CREDHUB_CA_CERT: ((master-bosh-ca.certificate))
+        CREDHUB_CLIENT: ((opensearch-ci-credhub-client-id))
+        CREDHUB_SECRET: ((opensearch-ci-credhub-client-secret))
+        CREDHUB_SERVER: ((credhub-api-server))
+  on_failure:
+    put: slack
+    params: 
+      <<: *slack-failure-params
+      text: |
+        :x: Failed to update test users
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 - name: deploy-opensearch-development
   serial_groups: [bosh-development]
@@ -907,20 +978,13 @@ resources:
     aws_region: us-gov-west-1
     tag: latest    
 
-# - name: master-bosh-root-cert
-#   type: s3-iam
-#   source:
-#     bucket: ((production-bucket-name))
-#     region_name: ((aws-region))
-#     versioned_file: ((master-bosh-cert-file))
-
-# - name: weekly
-#   type: time
-#   source:
-#     start: 12:00 AM
-#     stop: 1:00 AM
-#     location: America/New_York
-#     days: [Wednesday]
+- name: weekly
+  type: time
+  source:
+    start: 12:00 AM
+    stop: 1:00 AM
+    location: America/New_York
+    days: [Wednesday]
 
 resource_types:
 - name: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -118,6 +118,42 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
+# - name: update-test-users-dev
+#   serial: true
+#   plan:
+#   - get: deploy-logs-opensearch-config
+#     params: {depth: 1}
+#   - get: master-bosh-root-cert
+#   - get: general-task
+#   - get: weekly
+#     trigger: true
+#   - task: update-test-user-credentials
+#     image: general-task
+#     config:
+#       inputs:
+#         - name: deploy-logs-opensearch-config
+#         - name: master-bosh-root-cert
+#       platform: linux
+#       run:
+#         path: deploy-logs-opensearch-config/ci/update-test-user-passwords.sh
+#       params:
+#         BOSH_DIRECTOR_NAME: development
+#         UAA_API_URL: ((uaa-url-development))
+#         UAA_CLIENT_ID: ((uaa-client-id-development))
+#         UAA_CLIENT_SECRET: ((uaa-client-secret-development))
+#         TEST_USERS_CREDENTIAL_USERNAME_MAP: ((dev-test-users-credential-username-map))
+#         CREDHUB_CA_CERT: master-bosh-root-cert/((master-bosh-cert-file))
+#         CREDHUB_CLIENT: ((opensearch-ci-credhub-client-id))
+#         CREDHUB_SECRET: ((opensearch-ci-credhub-client-secret))
+#         CREDHUB_SERVER: ((credhub-api-server))
+#   on_failure:
+#     put: slack
+#     params: 
+#       <<: *slack-failure-params
+#       text: |
+#         :x: Failed to update test users
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
 - name: deploy-opensearch-development
   serial_groups: [bosh-development]
   plan:
@@ -201,6 +237,7 @@ jobs:
       trigger: true
     - get: opensearch-development-deployment
       trigger: true      
+      passed: [deploy-opensearch-development]
   - task: smoke-tests
     file: pipeline-tasks/bosh-logs-errand.yml
     params:
@@ -235,6 +272,7 @@ jobs:
       trigger: true
     - get: opensearch-development-deployment
       trigger: true
+      passed: [deploy-opensearch-development]
     - get: tests-timer
       trigger: true
     - get: playwright-python
@@ -265,6 +303,7 @@ jobs:
       trigger: true
     - get: opensearch-development-deployment
       trigger: true      
+      passed: [deploy-opensearch-development]
   - task: create-tenants
     file: pipeline-tasks/bosh-logs-errand.yml
     params:
@@ -398,6 +437,7 @@ jobs:
       passed: [deploy-opensearch-staging]
       trigger: true
     - get: opensearch-staging-deployment
+      passed: [deploy-opensearch-staging]
       trigger: true      
   - task: smoke-tests
     file: pipeline-tasks/bosh-logs-errand.yml
@@ -433,6 +473,7 @@ jobs:
       trigger: true
     - get: opensearch-staging-deployment
       trigger: true
+      passed: [deploy-opensearch-staging]
     - get: tests-timer
       trigger: true
     - get: playwright-python
@@ -463,6 +504,7 @@ jobs:
       trigger: true
     - get: opensearch-staging-deployment
       trigger: true      
+      passed: [deploy-opensearch-staging]
   - task: create-tenants
     file: pipeline-tasks/bosh-logs-errand.yml
     params:
@@ -613,7 +655,6 @@ jobs:
         :x: FAILED to deploy logs-OpenSearch in production
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-
 - name: smoke-tests-production
   serial_groups: [bosh-production]
   plan:
@@ -632,6 +673,7 @@ jobs:
       trigger: true
     - get: opensearch-production-deployment
       trigger: true          
+      passed: [deploy-opensearch-production]
   - task: smoke-tests
     file: pipeline-tasks/bosh-logs-errand.yml
     params:
@@ -666,6 +708,7 @@ jobs:
       trigger: true
     - get: opensearch-production-deployment
       trigger: true    
+      passed: [deploy-opensearch-production]
     - get: tests-timer
       trigger: true
     - get: playwright-python
@@ -695,7 +738,8 @@ jobs:
       passed: [deploy-opensearch-production]
       trigger: true
     - get: opensearch-production-deployment
-      trigger: true      
+      trigger: true     
+      passed: [deploy-opensearch-production] 
   - task: create-tenants
     file: pipeline-tasks/bosh-logs-errand.yml
     params:
@@ -862,6 +906,21 @@ resources:
     repository: playwright-python
     aws_region: us-gov-west-1
     tag: latest    
+
+# - name: master-bosh-root-cert
+#   type: s3-iam
+#   source:
+#     bucket: ((production-bucket-name))
+#     region_name: ((aws-region))
+#     versioned_file: ((master-bosh-cert-file))
+
+# - name: weekly
+#   type: time
+#   source:
+#     start: 12:00 AM
+#     stop: 1:00 AM
+#     location: America/New_York
+#     days: [Wednesday]
 
 resource_types:
 - name: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -984,7 +984,7 @@ resources:
     start: 12:00 AM
     stop: 1:00 AM
     location: America/New_York
-    days: [Wednesday]
+    days: [Thursday]
 
 resource_types:
 - name: registry-image

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Login to UAA
+uaac target "$UAA_API_URL"
+uaac token client get "$UAA_CLIENT_ID" -s "$UAA_CLIENT_SECRET"
+
+TEST_USER_CREDENTIAL_NAMES=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq '. | keys | join(" ")')
+
+for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
+  credential_name=$(echo "$credential_name" | tr -d '"')
+
+  printf "updating password credential for %s\n\n" "$credential_name"
+
+  # Generate a new password for the credential
+  credhub regenerate -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name"
+
+  # Get the UAA username for the corresponding Credhub credential
+  USERNAME=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq -r --arg credential_name "$credential_name" '.[$credential_name]')
+
+  printf "updating UAA password for %s\n\n" "$USERNAME"
+
+  # Get the new password from Credhub
+  PASSWORD=$(credhub get -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name" --output-json | jq -r '.value')
+
+  # Update the user password in UAA with the new value from Credhub
+  uaac password set "$USERNAME" --password "$PASSWORD"
+
+  # Activate the user, just to be safe
+  uaac user activate "$USERNAME"
+done
+
+
+

--- a/scripts/download-e2e-ci-results.sh
+++ b/scripts/download-e2e-ci-results.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+BUILD_NUMBER=$1
+
+if [[ -z "$BUILD_NUMBER" ]]; then
+  echo "build number is required as first argument"
+  exit 1
+fi
+
+ENVIRONMENT=${2:-production}
+
+CI_TASK_TARGET="fly -t ${FLY_TARGET:=ci} intercept -j deploy-logs-opensearch/smoke-tests-login-$ENVIRONMENT -s smoke-tests-login -b $BUILD_NUMBER"
+TEST_RESULTS_DIR="deploy-logs-opensearch-config/test-results"
+LOCAL_TARGET_DIR="ci-test-results"
+
+for test_dir in $($CI_TASK_TARGET -- ls $TEST_RESULTS_DIR); do
+  echo "found test dir: $test_dir"
+
+  for file in $($CI_TASK_TARGET -- ls "$TEST_RESULTS_DIR/$test_dir"); do
+    mkdir -p "$LOCAL_TARGET_DIR/$test_dir"
+    $CI_TASK_TARGET -- cat "$TEST_RESULTS_DIR/$test_dir/$file" > "$LOCAL_TARGET_DIR/$test_dir/$file"
+    echo "downloaded $file"
+  done
+done


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add script to download traces for failed e2e tests in CI
- Update README with instructions on using script to download e2e traces from CI
- Update job triggers in CI pipeline to avoid jobs running prematurely
- Add CI jobs to update passwords for test users every week so that e2e jobs do not fail due to expired test user passwords

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None - just adding useful scripts and making the e2e tests in CI more reliable
