### PR TITLE
Fix E2E tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1017,7 +1017,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/deploy-logs-opensearch.git
-      branch: fix-e2e-tests
+      branch: main
 
   - name: opensearch-stemcell-jammy
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -342,8 +342,8 @@ jobs:
           - get: opensearch-development-deployment
             trigger: true
             passed: [deploy-opensearch-development]
-          # - get: tests-timer
-          #   trigger: true
+          - get: tests-timer
+            trigger: true
           - get: playwright-python
           - get: general-task
       - task: provision-test-user-cf-access

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -342,8 +342,8 @@ jobs:
           - get: opensearch-development-deployment
             trigger: true
             passed: [deploy-opensearch-development]
-          - get: tests-timer
-            trigger: true
+          # - get: tests-timer
+          #   trigger: true
           - get: playwright-python
           - get: general-task
       - task: provision-test-user-cf-access

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1017,7 +1017,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/deploy-logs-opensearch.git
-      branch: main
+      branch: fix-e2e-tests
 
   - name: opensearch-stemcell-jammy
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -389,13 +389,13 @@ jobs:
           TEST_USER_4_USERNAME: ((development-test-user-4-username))
           TEST_USER_4_PASSWORD: ((development-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((development-test-user-4-totp-seed))
-    on_failure:
-      put: slack
-      params:
-        <<: *slack-failure-params
-        text: |
-          :x: E2E tests for OpenSearch in development FAILED
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+    # on_failure:
+    #   put: slack
+    #   params:
+    #     <<: *slack-failure-params
+    #     text: |
+    #       :x: E2E tests for OpenSearch in development FAILED
+    #       <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
   - name: tenant-development
     serial_groups: [bosh-development]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -389,13 +389,13 @@ jobs:
           TEST_USER_4_USERNAME: ((development-test-user-4-username))
           TEST_USER_4_PASSWORD: ((development-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((development-test-user-4-totp-seed))
-    # on_failure:
-    #   put: slack
-    #   params:
-    #     <<: *slack-failure-params
-    #     text: |
-    #       :x: E2E tests for OpenSearch in development FAILED
-    #       <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+    on_failure:
+      put: slack
+      params:
+        <<: *slack-failure-params
+        text: |
+          :x: E2E tests for OpenSearch in development FAILED
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
   - name: tenant-development
     serial_groups: [bosh-development]

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -115,21 +115,32 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
     index_input.fill("logs-app*")
     page.keyboard.press("Enter")
 
-    time_input_placeholder = (
-        page.locator("div").filter(has_text=re.compile(r"^Select a time field$")).first
-    )
-    time_input_placeholder.wait_for()
-    time_input_placeholder.click()
-
     wait_for_loading_finished(page)
 
-    timestamp_option = page.get_by_role("option", name="@timestamp")
-    timestamp_option.wait_for()
-    timestamp_option.click()
+    # time_input_placeholder = (
+    #     page.locator("div").filter(has_text=re.compile(r"^Select a time field$")).first
+    # )
+    # time_input_placeholder.wait_for()
+    # time_input_placeholder.click()
+
+    # wait_for_loading_finished(page)
+
+    # timestamp_option = page.get_by_role("option", name="@timestamp")
+    # timestamp_option.wait_for()
+    # timestamp_option.click()
+
+    time_field_input = page.locator("#timeField")
+    time_field_input.wait_for()
+    time_field_input.fill("@timestamp")
+    page.keyboard.press("Enter")
+
+    wait_for_loading_finished(page)
 
     add_trigger_button = page.get_by_role("button", name="Add trigger", exact=True)
     add_trigger_button.wait_for()
     add_trigger_button.click()
+
+    wait_for_loading_finished(page)
 
     trigger_name_input = page.locator('input[name="triggerDefinitions[0].name"]')
     trigger_name_input.wait_for()
@@ -146,6 +157,8 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
     )
     select_channel_placeholder.wait_for()
     select_channel_placeholder.click()
+
+    wait_for_loading_finished(page)
 
     action_channel_input = page.locator(
         '[id="triggerDefinitions\\[0\\]\\.actions\\.0\\.destination_id"]'

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -117,18 +117,6 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
 
     wait_for_loading_finished(page)
 
-    # time_input_placeholder = (
-    #     page.locator("div").filter(has_text=re.compile(r"^Select a time field$")).first
-    # )
-    # time_input_placeholder.wait_for()
-    # time_input_placeholder.click()
-
-    # wait_for_loading_finished(page)
-
-    # timestamp_option = page.get_by_role("option", name="@timestamp")
-    # timestamp_option.wait_for()
-    # timestamp_option.click()
-
     time_field_input = page.locator("#timeField")
     time_field_input.wait_for()
     time_field_input.fill("@timestamp")

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -8,6 +8,7 @@ from .utils import (
     click_delete_button,
     select_table_item_checkbox,
     open_actions_menu,
+    wait_for_loading_finished,
 )
 
 
@@ -119,6 +120,8 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
     )
     time_input_placeholder.wait_for()
     time_input_placeholder.click()
+
+    wait_for_loading_finished(page)
 
     timestamp_option = page.get_by_role("option", name="@timestamp")
     timestamp_option.wait_for()

--- a/scripts/download-e2e-ci-results.sh
+++ b/scripts/download-e2e-ci-results.sh
@@ -9,7 +9,7 @@ fi
 
 ENVIRONMENT=${2:-production}
 
-CI_TASK_TARGET="fly -t ${FLY_TARGET:=ci} intercept -j deploy-logs-opensearch/smoke-tests-login-$ENVIRONMENT -s smoke-tests-login -b $BUILD_NUMBER"
+CI_TASK_TARGET="fly -t ${FLY_TARGET:=ci} intercept -j deploy-logs-opensearch/e2e-tests-$ENVIRONMENT -s e2e-tests -b $BUILD_NUMBER"
 TEST_RESULTS_DIR="deploy-logs-opensearch-config/test-results"
 LOCAL_TARGET_DIR="ci-test-results"
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/2435

- Fixes for E2E test flakiness

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The E2E tests will verify that access control to notification objects (recipient groups, channels, and monitors) works as designed, which will give us confidence that users cannot see what they should not see
