### PR TITLE
fix CI script for provisioning test user CF access to handle environm…

### DIFF
--- a/ci/provision-test-user-cf-access.sh
+++ b/ci/provision-test-user-cf-access.sh
@@ -66,6 +66,10 @@ EOF
 
 function delete_sandbox_org_roles() {
   SANDBOX_ORG="sandbox-$(echo "$1" | cut -d '@' -f2 | cut -d '.' -f1)"
+  if ! cf org "$SANDBOX_ORG" > /dev/null; then
+    return
+  fi
+
   SANDBOX_SPACE=$(echo "$1" | cut -d '@' -f1)
   SANDBOX_ORG_GUID=$(cf org "$SANDBOX_ORG" --guid)
   USER_GUID=$(get_user_guid "$1")


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix CI script for provisioning test user CF access to handle environments where sandbox org does not exist

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. The script contents are not sensitive and the changes to remove sandbox membership for test users are necessary for testing as outlined in https://github.com/cloud-gov/private/issues/2435
