### PR TITLE
E2e test improvements

### DIFF
--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -43,6 +43,18 @@ def create_email_recipient_group(page, user, email_recipient_group_name):
 
     wait_for_header(page, "Email recipient groups")
 
+    rows_per_page_button = page.get_by_role(
+        "button", name=re.compile(r"^Rows per page: [0-9]+$")
+    )
+    rows_per_page_button.wait_for()
+    rows_per_page_button.click()
+
+    fifty_rows_button = page.get_by_role("button", name="50 rows", exact=True)
+    fifty_rows_button.wait_for()
+    fifty_rows_button.click()
+
+    wait_for_loading_finished(page)
+
     expect(page.get_by_text(email_recipient_group_name, exact=True)).to_be_visible()
 
 

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -142,9 +142,25 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
 
     wait_for_loading_finished(page)
 
+    query_time_interval = page.locator('input[name="bucketValue"]')
+    query_time_interval.wait_for()
+    query_time_interval.fill("15")
+
+    query_time_interval_unit_select = page.locator("#bucketUnitOfTime")
+    query_time_interval_unit_select.wait_for()
+    query_time_interval_unit_select.select_option(label="minute(s)")
+
     trigger_name_input = page.locator('input[name="triggerDefinitions[0].name"]')
     trigger_name_input.wait_for()
     trigger_name_input.fill(trigger_name)
+
+    trigger_threshold_input = page.locator(
+        'input[name="triggerDefinitions[0].thresholdValue"]'
+    )
+    trigger_threshold_input.wait_for()
+    # set threshold to 1 billion records for alert to trigger so that e2e tests for
+    # access do not actually trigger alerts
+    trigger_threshold_input.fill("1000000000")
 
     action_name_input = page.get_by_placeholder("Enter action name")
     action_name_input.wait_for()

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -124,7 +124,7 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
 
     index_input = page.locator("#index")
     index_input.wait_for()
-    index_input.fill("logs-app*")
+    index_input.fill("logs-app-*")
     page.keyboard.press("Enter")
 
     wait_for_loading_finished(page)
@@ -142,17 +142,21 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
 
     wait_for_loading_finished(page)
 
+    trigger_name_input = page.locator('input[name="triggerDefinitions[0].name"]')
+    trigger_name_input.wait_for()
+    trigger_name_input.fill(trigger_name)
+
     query_time_interval = page.locator('input[name="bucketValue"]')
     query_time_interval.wait_for()
     query_time_interval.fill("15")
+
+    wait_for_loading_finished(page)
 
     query_time_interval_unit_select = page.locator("#bucketUnitOfTime")
     query_time_interval_unit_select.wait_for()
     query_time_interval_unit_select.select_option(label="minute(s)")
 
-    trigger_name_input = page.locator('input[name="triggerDefinitions[0].name"]')
-    trigger_name_input.wait_for()
-    trigger_name_input.fill(trigger_name)
+    wait_for_loading_finished(page)
 
     trigger_threshold_input = page.locator(
         'input[name="triggerDefinitions[0].thresholdValue"]'
@@ -161,6 +165,8 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
     # set threshold to 1 billion records for alert to trigger so that e2e tests for
     # access do not actually trigger alerts
     trigger_threshold_input.fill("1000000000")
+
+    wait_for_loading_finished(page)
 
     action_name_input = page.get_by_placeholder("Enter action name")
     action_name_input.wait_for()
@@ -189,6 +195,8 @@ def create_alert_monitor(page, monitor_name, trigger_name, action_name, channel_
     create_monitor_button = page.get_by_role("button", name="Create", exact=True)
     create_monitor_button.wait_for()
     create_monitor_button.click()
+
+    wait_for_loading_finished(page)
 
     expect(page.get_by_role("heading", name=monitor_name, exact=True)).to_be_visible()
     expect(page.get_by_text("Enabled")).to_be_visible()


### PR DESCRIPTION
## Changes proposed in this pull request:

- [update CF test user access provisioning script to handle case where sandbox space does not yet exist](https://github.com/cloud-gov/deploy-logs-opensearch/commit/ae3de6225318bd2799615ace0e5e28e72a85ffb3) 
- [update email group creation test to expand table of results when checking for created group](https://github.com/cloud-gov/deploy-logs-opensearch/commit/4cca97455ca758dde23bf44e8566349e1a379720) 
- [update monitor creation test to use a very high threshold so that the monitor does not trigger alerts](https://github.com/cloud-gov/deploy-logs-opensearch/commit/a0404570f1b5af12c4027de59f142eb3d69129a0) 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, these changes are just to improve E2E test stability
