### PR TITLE
Ignore E2E alerting tests

### DIFF
--- a/ci/e2e-tests.yml
+++ b/ci/e2e-tests.yml
@@ -9,4 +9,4 @@ run:
   - -exc
   - |
     cd deploy-logs-opensearch-config
-    ./scripts/e2e.sh
+    ./scripts/e2e.sh -k 'test_user_login'


### PR DESCRIPTION
## Changes proposed in this pull request:

- add flag in CI script to temporarily ignore e2e tests for alerting access

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just changing what tests are run by CI
