### PR TITLE
adding in z2 zone 

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -44,7 +44,7 @@ instance_groups:
           client_id: opensearch_client_id
   persistent_disk_type: logs_opensearch_os_data
   stemcell: default
-  azs: [z1]
+  azs: [z1,z2]
   vm_type: t3.large
   networks:
   - name: services
@@ -103,8 +103,7 @@ instance_groups:
         - 'alert tcp any any -> any 9200 (msg:"Unexpected opensearch action"; content:"POST"; http_method; content: "logs-opensearch-app"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080002; rev:1;)'
         - 'alert tcp any any -> any 9200 (msg:"Unexpected opensearch action"; content:"DELETE"; http_method; content: "logs-opensearch-app"; http_uri; classtype:web-application-attack; sid:343080004; rev:1;)'
     release: jammy-snort
-  azs:
-  - z1
+  azs: [z1,z2]
   persistent_disk_type: logs_opensearch_os_master
   stemcell: default
   vm_type: t3.large
@@ -255,7 +254,7 @@ instance_groups:
       opensearch_dashboards:
         host: opensearch_dashboards.opensearch.internal
   stemcell: default
-  azs: [z1]
+  azs: [z1,z2]
   vm_type: t3.large
   networks:
   - name: services
@@ -316,7 +315,7 @@ instance_groups:
           ssl_cert: ((archiver_syslog_server_tls.certificate))
           ssl_key: ((archiver_syslog_server_tls.private_key))
     release: opensearch
-  azs: [z1]
+  azs: [z1,z2]
   networks:
   - name: services
   persistent_disk_type: logs_opensearch_ingestor
@@ -393,7 +392,7 @@ instance_groups:
     release: opensearch
   persistent_disk_type: logs_opensearch_ingestor
   stemcell: default
-  azs: [z1]
+  azs: [z1,z2]
   vm_type: t3.medium
   vm_extensions:
   - logs-opensearch-ingestor-profile
@@ -461,7 +460,7 @@ instance_groups:
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  azs: [z1]
+  azs: [z1,z2]
   networks:
   - name: services
   persistent_disk_type: logs_opensearch_ingestor
@@ -531,7 +530,7 @@ instance_groups:
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  azs: [z1]
+  azs: [z1,z2]
   networks:
   - name: services
   persistent_disk_type: logs_opensearch_ingestor
@@ -602,7 +601,7 @@ instance_groups:
     release: opensearch
   persistent_disk_type: logs_opensearch_ingestor
   stemcell: default
-  azs: [z1]
+  azs: [z1,z2]
   vm_type: t3.large
   vm_extensions:
   - logs-opensearch-ingestor-profile
@@ -660,8 +659,7 @@ instance_groups:
   vm_extensions:
   - 15GB_ephemeral_disk
   stemcell: default
-  azs:
-  - z1
+  azs: [z1,z2]
   networks:
    - name: services
   env:


### PR DESCRIPTION
## Changes proposed in this pull request:
Switching to use two azs
Part of https://github.com/cloud-gov/private/issues/2469 - Add az2 to services network
This will only affect new and vms without persistent disk (will avoid everything but maintenance and dashboard)
## Security considerations
Increases fault tolerance of availability zones
