### PR TITLE
future logs-app will be smaller so the amount of shards needed for it should too

### DIFF
--- a/opensearch-production.yml
+++ b/opensearch-production.yml
@@ -52,9 +52,9 @@ instance_groups:
     release: opensearch
     properties:
       opensearch_config:
-        rollover_document_size: 30gb
+        rollover_document_size: 45gb
         rollover_index_age: 1d
-        shard_count: 18
+        shard_count: 12
         metrics_shard_count: 6
 
 addons:


### PR DESCRIPTION
## Changes proposed in this pull request:
- change shard count from 18 to 12
- rollover is now 45, this means the index wlll need to be 45x12=540(average is 400 right now) for logs app.
- with less shards, the index should be spread more evenly making replicas on nodes with no primaries

## Security considerations
None
