### PR TITLE
lowering number of minimum documents to 150

### DIFF
--- a/opensearch-jobs.yml
+++ b/opensearch-jobs.yml
@@ -209,7 +209,7 @@ instance_groups:
       smoke_tests:
         count_test:
           index_pattern: logs-app-*
-          minimum: 200
+          minimum: 150
           run: true
           time_field: '@timestamp'
           time_interval: 5m


### PR DESCRIPTION
## Changes proposed in this pull request:
- lowering number to 150 as container metric is no longer inflating app-logs numbers
-
-
## Security considerations
None
