### PR TITLE
Add reset-aide job workaround

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -66,6 +66,10 @@ groups:
       - e2e-tests-production
       - tenant-production
       - audit-to-s3-production
+  - name: reset-aide
+    jobs:
+      - reset-aide-opensearch-production
+
 
 jobs:
   - name: set-self
@@ -1221,6 +1225,35 @@ jobs:
           BOSH_ERRAND: upload-dashboards-objects
           BOSH_FLAGS: "--keep-alive"
           BOSH_CA_CERT: ((bosh_ca_cert_store.certificate))
+
+  - name: reset-aide-opensearch-production
+    serial: true
+    serial_groups: [reset-aide]
+    plan:
+      - in_parallel:
+          - get: general-task
+          - get: deploy-logs-opensearch-config
+      - in_parallel:
+          - task: reset-aide-opensearch_dashboards
+            image: general-task
+            file: deploy-logs-opensearch-config/ci/reset-aide.yml
+            params:
+              BOSH_ENVIRONMENT: ((bosh_production_environment))
+              BOSH_CLIENT: ((bosh_client))
+              BOSH_CLIENT_SECRET: (bosh_production_client_secret))
+              BOSH_CA_CERT: ((bosh_ca_cert_store.certificate))
+              BOSH_DEPLOYMENT_NAME: logs-opensearch
+              BOSH_INSTANCE_NAME: opensearch_dashboards
+          - task: reset-aide-ingestor_cloudwatch_logs
+            image: general-task
+            file: deploy-logs-opensearch-config/ci/reset-aide.yml
+            params:
+              BOSH_ENVIRONMENT: ((bosh_production_environment))
+              BOSH_CLIENT: ((bosh_client))
+              BOSH_CLIENT_SECRET: (bosh_production_client_secret))
+              BOSH_CA_CERT: ((bosh_ca_cert_store.certificate))
+              BOSH_DEPLOYMENT_NAME: logs-opensearch
+              BOSH_INSTANCE_NAME: ingestor_cloudwatch_logs
 
 resources:
   - name: opensearch-release-git-repo

--- a/ci/reset-aide.sh
+++ b/ci/reset-aide.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu
+
+bosh -d $BOSH_DEPLOYMENT_NAME ssh $BOSH_INSTANCE_NAME "sudo /var/vcap/jobs/aide/bin/post-deploy; sudo /etc/cron.hourly/run-report"

--- a/ci/reset-aide.yml
+++ b/ci/reset-aide.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+
+inputs:
+  - { name: deploy-logs-opensearch-config }
+
+
+run:
+  path: deploy-logs-opensearch-config/ci/reset-aide.sh
+
+params:
+  BOSH_CA_CERT:
+  BOSH_ENVIRONMENT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:
+  BOSH_DEPLOYMENT_NAME:
+  BOSH_INSTANCE_NAME:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add pipeline job to reset aide on `opensearch_dashboard` and `ingestor_cloudwatch_logs` instance groups after a deploy
- rsync and intel microcode file updates are occurring outside of the bosh deployment lifecycle causing aide alerts
- This makes it quicker for the operators to reset aide post-deploy, something more permanent will be worked on later
- Part of https://github.com/cloud-gov/product/issues/2836

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Automates commands manually executed by the maintenance person
