### PR TITLE
Add aide reset after upload kibana objects

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1225,6 +1225,17 @@ jobs:
           BOSH_ERRAND: upload-dashboards-objects
           BOSH_FLAGS: "--keep-alive"
           BOSH_CA_CERT: ((bosh_ca_cert_store.certificate))
+      # Updating the dashboards touches files on the os, reset the aide db
+      - task: reset-aide-opensearch_dashboards
+        image: general-task
+        file: deploy-logs-opensearch-config/ci/reset-aide.yml
+        params:
+          BOSH_ENVIRONMENT: ((bosh_production_environment))
+          BOSH_CLIENT: ((bosh_client))
+          BOSH_CLIENT_SECRET: ((bosh_production_client_secret))
+          BOSH_CA_CERT: ((bosh_ca_cert_store.certificate))
+          BOSH_DEPLOYMENT_NAME: logs-opensearch
+          BOSH_INSTANCE_NAME: opensearch_dashboards
 
   - name: reset-aide-opensearch-production
     serial: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Found that the task `upload-dashboards-objects` is changing files on the OS as a normal part of its process, this is fine but trips the aide check on the subsequent run.
- The change forces the aide db to be reset on the `opensearch_dashboard` vms after the dashboard objects are uploaded, the tasks are not and should not be run in parallel.  This will add 2-3 minutes to the job to run but should cut down on the false positive aide alerts to have to investigate.
- Leaving the temporary `reset-aide-opensearch-production` in case more edge cases to this are found
- Part of https://github.com/cloud-gov/product/issues/2836

## Security considerations

No new functionality introduced, just changed when some of it runs
