### PR TITLE
Revert "Enable keystore errand (#232)"

### DIFF
--- a/ci/e2e-tests.yml
+++ b/ci/e2e-tests.yml
@@ -9,4 +9,4 @@ run:
   - -exc
   - |
     cd deploy-logs-opensearch-config
-    ./scripts/e2e.sh
+    ./scripts/e2e.sh -k 'test_user_login'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -437,7 +437,6 @@ jobs:
             - deploy-logs-opensearch-test-config/opsfiles/cf-development.yml
             - deploy-logs-opensearch-test-config/opsfiles/opensearch-notification.yml
             - deploy-logs-opensearch-test-config/opsfiles/test-name.yml
-            - deploy-logs-opensearch-test-config/opsfiles/add-keystore-credentials-errand.yml
           vars_files:
             - terraform-secrets/terraform.yml
 
@@ -537,7 +536,6 @@ jobs:
             - deploy-logs-opensearch-config/opsfiles/enable-syslog.yml
             - deploy-logs-opensearch-config/opsfiles/cf-development.yml
             - deploy-logs-opensearch-config/opsfiles/opensearch-notification.yml
-            - deploy-logs-opensearch-config/opsfiles/add-keystore-credentials-errand.yml
           vars_files:
             - terraform-secrets/terraform.yml
     on_failure:
@@ -629,8 +627,7 @@ jobs:
         image: playwright-python
         file: deploy-logs-opensearch-config/ci/e2e-tests.yml
         params:
-          AUTH_PROXY_URL: ((development-auth-proxy-url))
-          UAA_BASE_URL: ((development-uaa-base-url))
+          CF_SYSTEM_DOMAIN: ((cf-system-domain-development))
           CF_ORG_1_NAME: ((test-org-1))
           CF_ORG_2_NAME: ((test-org-2))
           CF_ORG_3_NAME: ((test-org-3))
@@ -650,10 +647,6 @@ jobs:
           TEST_USER_4_USERNAME: ((development-test-user-4-username))
           TEST_USER_4_PASSWORD: ((development-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((development-test-user-4-totp-seed))
-
-          SMTP_SENDER_HOST: ((log-alerts-smtp-sender-host))
-          SMTP_SENDER_PORT: ((log-alerts-smtp-sender-port))
-          SMTP_SENDER_FROM: ((development-log-alerts-smtp-sender-from))
     on_failure:
       put: slack
       params:
@@ -776,7 +769,6 @@ jobs:
             - deploy-logs-opensearch-config/opsfiles/enable-syslog.yml
             - deploy-logs-opensearch-config/opsfiles/cf-staging.yml
             - deploy-logs-opensearch-config/opsfiles/opensearch-notification.yml
-            - deploy-logs-opensearch-config/opsfiles/add-keystore-credentials-errand.yml
           vars_files:
             - terraform-secrets/terraform.yml
     on_failure:
@@ -868,8 +860,7 @@ jobs:
         image: playwright-python
         file: deploy-logs-opensearch-config/ci/e2e-tests.yml
         params:
-          AUTH_PROXY_URL: ((staging-auth-proxy-url))
-          UAA_BASE_URL: ((staging-uaa-base-url))
+          CF_SYSTEM_DOMAIN: ((cf-system-domain-staging))
 
           CF_ORG_1_NAME: ((test-org-1))
           CF_ORG_2_NAME: ((test-org-2))
@@ -890,10 +881,6 @@ jobs:
           TEST_USER_4_USERNAME: ((staging-test-user-4-username))
           TEST_USER_4_PASSWORD: ((staging-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((staging-test-user-4-totp-seed))
-
-          SMTP_SENDER_HOST: ((log-alerts-smtp-sender-host))
-          SMTP_SENDER_PORT: ((log-alerts-smtp-sender-port))
-          SMTP_SENDER_FROM: ((staging-log-alerts-smtp-sender-from))
     on_failure:
       put: slack
       params:
@@ -1018,7 +1005,6 @@ jobs:
             - deploy-logs-opensearch-config/opsfiles/enable-syslog.yml
             - deploy-logs-opensearch-config/opsfiles/cf-production.yml
             - deploy-logs-opensearch-config/opsfiles/opensearch-notification.yml
-            - deploy-logs-opensearch-config/opsfiles/add-keystore-credentials-errand.yml
           vars_files:
             - terraform-secrets/terraform.yml
     on_failure:
@@ -1143,8 +1129,7 @@ jobs:
         image: playwright-python
         file: deploy-logs-opensearch-config/ci/e2e-tests.yml
         params:
-          AUTH_PROXY_URL: ((production-auth-proxy-url))
-          UAA_BASE_URL: ((production-uaa-base-url))
+          CF_SYSTEM_DOMAIN: ((cf-system-domain-production))
 
           CF_ORG_1_NAME: ((test-org-1))
           CF_ORG_2_NAME: ((test-org-2))
@@ -1165,10 +1150,6 @@ jobs:
           TEST_USER_4_USERNAME: ((production-test-user-4-username))
           TEST_USER_4_PASSWORD: ((production-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((production-test-user-4-totp-seed))
-
-          SMTP_SENDER_HOST: ((log-alerts-smtp-sender-host))
-          SMTP_SENDER_PORT: ((log-alerts-smtp-sender-port))
-          SMTP_SENDER_FROM: ((production-log-alerts-smtp-sender-from))
     on_failure:
       put: slack
       params:
@@ -1365,7 +1346,7 @@ resources:
       bucket: ((tf-state-bucket-development))
       versioned_file: ((tf-state-file-development))
       region_name: ((aws-region))
-
+  
   - name: terraform-yaml-staging
     type: s3-iam
     source:

--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -2,8 +2,7 @@ import os
 import sys
 
 required_env_vars = [
-    "AUTH_PROXY_URL",
-    "UAA_BASE_URL",
+    "CF_SYSTEM_DOMAIN",
     "CF_ORG_1_NAME",
     "CF_ORG_2_NAME",
     "CF_ORG_3_NAME",
@@ -19,9 +18,6 @@ required_env_vars = [
     "TEST_USER_4_USERNAME",
     "TEST_USER_4_PASSWORD",
     "TEST_USER_4_TOTP_SEED",
-    "SMTP_SENDER_HOST",
-    "SMTP_SENDER_PORT",
-    "SMTP_SENDER_FROM",
 ]
 
 for env_var in required_env_vars:
@@ -29,11 +25,8 @@ for env_var in required_env_vars:
         print(f"{env_var} is a required environment variable, exiting")
         sys.exit(1)
 
-AUTH_PROXY_URL = os.environ["AUTH_PROXY_URL"]
-UAA_BASE_URL = os.environ["AUTH_PROXY_URL"]
+AUTH_PROXY_URL = "https://logs.{}".format(os.environ["CF_SYSTEM_DOMAIN"])
+UAA_BASE_URL = "https://login.{}".format(os.environ["CF_SYSTEM_DOMAIN"])
 CF_ORG_1_NAME = os.environ["CF_ORG_1_NAME"]
 CF_ORG_2_NAME = os.environ["CF_ORG_2_NAME"]
 CF_ORG_3_NAME = os.environ["CF_ORG_3_NAME"]
-SMTP_SENDER_HOST = os.environ["SMTP_SENDER_HOST"]
-SMTP_SENDER_PORT = os.environ["SMTP_SENDER_PORT"]
-SMTP_SENDER_FROM = os.environ["SMTP_SENDER_FROM"]

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -11,8 +11,6 @@ from .utils import (
     wait_for_loading_finished,
 )
 
-from . import SMTP_SENDER_HOST, SMTP_SENDER_PORT, SMTP_SENDER_FROM
-
 
 def wait_for_channels_header(page):
     wait_for_header(page, re.compile(r"^Channels\s\([0-9]+\)$"))
@@ -60,55 +58,7 @@ def create_email_recipient_group(page, user, email_recipient_group_name):
     expect(page.get_by_text(email_recipient_group_name, exact=True)).to_be_visible()
 
 
-def create_email_smtp_sender(page, user, email_sender_name):
-    create_group_button = (
-        page.locator("div")
-        .filter(has_text=re.compile(r"^Create SMTP sender$"))
-        .get_by_role("link")
-    )
-    create_group_button.wait_for()
-    create_group_button.click()
-
-    sender_name_input = page.get_by_placeholder("Enter sender name")
-    sender_name_input.wait_for()
-    sender_name_input.fill(email_sender_name)
-
-    sender_email_input = page.get_by_label("Email address")
-    sender_email_input.wait_for()
-    sender_email_input.fill(SMTP_SENDER_FROM)
-
-    sender_host_input = page.get_by_label("Host")
-    sender_host_input.wait_for()
-    sender_host_input.fill(SMTP_SENDER_HOST)
-
-    sender_host_input = page.get_by_label("Port")
-    sender_host_input.wait_for()
-    sender_host_input.fill(SMTP_SENDER_PORT)
-
-    create_group_button = page.get_by_role("button", name="Create")
-    create_group_button.wait_for()
-    create_group_button.click()
-
-    wait_for_header(page, "Email senders")
-
-    rows_per_page_button = page.get_by_role(
-        "button", name=re.compile(r"^Rows per page: [0-9]+$")
-    )
-    rows_per_page_button.wait_for()
-    rows_per_page_button.click()
-
-    fifty_rows_button = page.get_by_role("button", name="50 rows", exact=True)
-    fifty_rows_button.wait_for()
-    fifty_rows_button.click()
-
-    wait_for_loading_finished(page)
-
-    expect(page.get_by_text(email_sender_name, exact=True)).to_be_visible()
-
-
-def create_notifications_channel(
-    page, email_recipient_group_name, email_sender_name, channel_name
-):
+def create_notifications_channel(page, email_recipient_group_name, channel_name):
     create_channel_button = (
         page.locator("div")
         .filter(has_text=re.compile(r"^Create channel$"))
@@ -138,7 +88,7 @@ def create_notifications_channel(
     choose_sender_placeholder.wait_for()
     choose_sender_placeholder.click()
 
-    cloud_smtp_sender = page.get_by_role("option", name=email_sender_name)
+    cloud_smtp_sender = page.get_by_role("option", name="cloudgovemail")
     cloud_smtp_sender.wait_for()
     cloud_smtp_sender.click()
 
@@ -288,26 +238,6 @@ def delete_email_recipient_group(page, recipient_group_name):
     wait_for_header(page, re.compile(r"^Email recipient groups$"))
 
     expect(page.get_by_text(recipient_group_name, exact=True)).not_to_be_visible()
-
-
-def delete_email_smtp_sender(page, email_sender_name):
-    expect(page.get_by_text(email_sender_name, exact=True)).to_be_visible()
-
-    select_table_item_checkbox(page, email_sender_name)
-
-    delete_email_smtp_sender_button = page.get_by_role(
-        "button", name="Delete", exact=True
-    ).first
-    delete_email_smtp_sender_button.wait_for()
-    delete_email_smtp_sender_button.click()
-
-    fill_delete_confirm_placeholder(page)
-
-    click_delete_button(page)
-
-    wait_for_header(page, re.compile(r"^Email senders$"))
-
-    expect(page.get_by_text(email_sender_name, exact=True)).not_to_be_visible()
 
 
 def delete_alert_monitor(page, monitor_name):

--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -5,13 +5,11 @@ import time
 from playwright.sync_api import expect
 from .notifications import (
     create_email_recipient_group,
-    create_email_smtp_sender,
     create_notifications_channel,
     delete_notifications_channel,
     delete_email_recipient_group,
     create_alert_monitor,
     delete_alert_monitor,
-    delete_email_smtp_sender,
 )
 from .utils import (
     log_in,
@@ -30,9 +28,6 @@ test_object_prefix = "E2E-Test"
 test_email_recipient_group_name = (
     f"{test_object_prefix}EmailRecipientGroup-{test_run_timestamp}"
 )
-test_email_smtp_sender_name = (
-    f"{test_object_prefix}EmailSmtpSender-{test_run_timestamp}"
-).lower()
 test_channel_name = f"{test_object_prefix}Channel-{test_run_timestamp}"
 test_monitor_name = f"{test_object_prefix}Monitor-{test_run_timestamp}"
 test_trigger_name = f"{test_object_prefix}Trigger-{test_run_timestamp}"
@@ -50,17 +45,10 @@ def test_user_can_create_alerts(user_1, page):
 
     create_email_recipient_group(page, user_1, test_email_recipient_group_name)
 
-    click_contextual_menu_link(page, "Email senders")
-
-    create_email_smtp_sender(page, user_1, test_email_smtp_sender_name)
-
     click_contextual_menu_link(page, "Channels")
 
     create_notifications_channel(
-        page,
-        test_email_recipient_group_name,
-        test_email_smtp_sender_name,
-        test_channel_name,
+        page, test_email_recipient_group_name, test_channel_name
     )
 
     open_primary_menu_link(page, "Alerting")
@@ -209,7 +197,3 @@ def test_user_can_delete_alerts(user_1, page):
     click_contextual_menu_link(page, "Email recipient groups")
 
     delete_email_recipient_group(page, test_email_recipient_group_name)
-
-    click_contextual_menu_link(page, "Email senders")
-
-    delete_email_smtp_sender(page, test_email_smtp_sender_name)

--- a/opensearch-base.yml
+++ b/opensearch-base.yml
@@ -67,7 +67,7 @@ instance_groups:
   stemcell: default
   azs: [z1,z2]
   vm_type: t3.large\
-  vm_extensions:
+  vm_extensions: 
   - logs-opensearch-profile
   networks:
   - name: services
@@ -109,7 +109,7 @@ instance_groups:
   persistent_disk_type: logs_opensearch_os_data
   stemcell: default
   azs: [z1,z2]
-  vm_extensions:
+  vm_extensions: 
   - logs-opensearch-profile
   vm_type: t3.large
   networks:
@@ -130,8 +130,8 @@ instance_groups:
 - name: opensearch_manager
   instances: 3
   vm_extensions:
-  - logs-opensearch-profile
   - 15GB_ephemeral_disk
+  - logs-opensearch-profile
   jobs:
   - name: bpm
     release: bpm
@@ -173,9 +173,7 @@ instance_groups:
 #########################################################
 - name: maintenance
   instances: 1
-  vm_extensions:
-    - 15GB_ephemeral_disk
-    - logs-opensearch-ingestor-profile
+  vm_extensions: [15GB_ephemeral_disk, logs-opensearch-ingestor-profile]
   jobs:
   - name: bpm
     release: bpm


### PR DESCRIPTION
This reverts commit e422bf5ac3e12e920d3cd9916ef271c0f4d4bc14.

## Changes proposed in this pull request:

- Remove keystore errand 
- Disable alerting e2e tests

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
