### PR TITLE
increase timeout for e2e test assertions to 10 seconds

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,8 +1,11 @@
 from os import getenv
+from playwright.sync_api import expect
 
 import pytest
 
 from .user import User
+
+expect.set_options(timeout=10_000)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes proposed in this pull request:

- increase timeout for e2e test assertions to 10 seconds to reduce test flakiness 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just improving e2e test reliability.
