### PR TITLE
E2E test improvements

### DIFF
--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -323,6 +323,8 @@ def delete_alert_monitor(page, monitor_name):
 
     click_delete_button(page)
 
+    wait_for_loading_finished(page)
+
     wait_for_header(page, "Monitors")
 
     expect(page.get_by_text(monitor_name, exact=True)).not_to_be_visible()


### PR DESCRIPTION


## Changes proposed in this pull request:

- add more waiting to increase reliaiblity of e2e test deleting alert monitor test
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for the changes. The alerting e2e tests verify that access controls are working as expected.
