### PR TITLE
Reduce E2E test flakiness

### DIFF
--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -12,6 +12,7 @@ from .utils import (
     update_rows_per_table,
     dismiss_toast_notifications,
     click_save_button,
+    get_dismiss_toast_notification_buttons,
 )
 
 from . import SMTP_SENDER_HOST, SMTP_SENDER_PORT, SMTP_SENDER_FROM
@@ -331,6 +332,10 @@ def delete_alert_monitor(page, monitor_name):
 
 
 def failure_on_edit_save(page, expected_failure_message):
+    toast = get_dismiss_toast_notification_buttons(page)
+    if toast.is_visible():
+        toast.click()
+
     click_save_button(page)
 
     failure_message = page.get_by_text(expected_failure_message)

--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -28,7 +28,7 @@ from .utils import (
     click_table_edit_button,
     click_actions_edit_link,
     click_save_button,
-    dismiss_toast_notification,
+    wait_and_dismiss_toast_notification,
 )
 from . import AUTH_PROXY_URL, CF_ORG_1_NAME, CF_ORG_2_NAME, CF_ORG_3_NAME
 
@@ -139,8 +139,9 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
 
     expect(page.get_by_role("heading", name="Edit recipient group")).to_be_visible()
 
-    dismiss_toast_notification(page)
+    wait_and_dismiss_toast_notification(page)
     fill_email_recipient_group_details(page, user_3, test_email_recipient_group_name)
+    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update recipient group")
 
     click_contextual_menu_link(page, "Email senders")
@@ -157,8 +158,9 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
 
     expect(page.get_by_role("heading", name="Edit SMTP sender")).to_be_visible()
 
-    dismiss_toast_notification(page)
+    wait_and_dismiss_toast_notification(page)
     fill_email_smtp_sender_details(page, test_email_smtp_sender_name)
+    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update sender")
 
     click_contextual_menu_link(page, "Channels")
@@ -180,7 +182,7 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
     click_actions_edit_link(page)
     wait_for_loading_finished(page)
 
-    dismiss_toast_notification(page)
+    wait_and_dismiss_toast_notification(page)
 
     channel_name_input = page.get_by_label("Name")
     channel_name_input.wait_for()
@@ -190,6 +192,7 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
     slack_webhook_input.wait_for()
     slack_webhook_input.fill("https://hooks.slack.com/services/foo/bar")
 
+    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update channel")
 
     open_primary_menu_link(page, "Alerting")

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -169,14 +169,18 @@ def update_rows_per_table(page, rows_option="50 rows"):
     fifty_rows_button.click()
 
 
-def dismiss_toast_notification(page):
-    toast = page.get_by_label("Dismiss toast")
+def get_dismiss_toast_notification_buttons(page):
+    return page.get_by_label("Dismiss toast")
+
+
+def wait_and_dismiss_toast_notification(page):
+    toast = get_dismiss_toast_notification_buttons(page)
     toast.wait_for()
     toast.click()
 
 
 def dismiss_toast_notifications(page):
-    dismiss_toast_buttons = page.get_by_label("Dismiss toast")
+    dismiss_toast_buttons = get_dismiss_toast_notification_buttons(page)
     for i in range(dismiss_toast_buttons.count()):
         dismiss_toast_buttons.nth(i).click()
 


### PR DESCRIPTION

## Changes proposed in this pull request:

- add additional assertions waiting for page load to finish to reduce test flakiness when testing read but not write access for alerting
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The E2E tests themselves are used to validate that access controls for alerting are working correctly
