### PR TITLE
update e2e test to handle dismissing multiple toast notifications

### DIFF
--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -332,9 +332,7 @@ def delete_alert_monitor(page, monitor_name):
 
 
 def failure_on_edit_save(page, expected_failure_message):
-    toast = get_dismiss_toast_notification_buttons(page)
-    if toast.is_visible():
-        toast.click()
+    dismiss_toast_notifications(page)
 
     click_save_button(page)
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update e2e test to handle dismissing multiple toast notifications to reduce test flakiness
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The E2E tests themselves are used to validate that access controls for alerting are working correctly
