### PR TITLE
Fix for E2E tests

### DIFF
--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -182,7 +182,8 @@ def wait_and_dismiss_toast_notification(page):
 def dismiss_toast_notifications(page):
     dismiss_toast_buttons = get_dismiss_toast_notification_buttons(page)
     for i in range(dismiss_toast_buttons.count()):
-        dismiss_toast_buttons.nth(i).click()
+        if dismiss_toast_buttons.nth(i).is_visible():
+            dismiss_toast_buttons.nth(i).click()
 
 
 def click_save_button(page):


### PR DESCRIPTION
## Changes proposed in this pull request:

- add visibility check before attempting to click buttons to dismiss toast notifications
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The E2E tests for alerting verify that access controls are working as expected