### PR TITLE
E2e fixes

### DIFF
--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -174,7 +174,6 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
     expect(page.get_by_role("heading", name="Edit SMTP sender")).to_be_visible()
 
     fill_email_smtp_sender_details(page, test_email_smtp_sender_name)
-    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update sender")
 
     click_contextual_menu_link(page, "Channels")
@@ -204,7 +203,6 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
     slack_webhook_input.wait_for()
     slack_webhook_input.fill("https://hooks.slack.com/services/foo/bar")
 
-    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update channel")
 
     open_primary_menu_link(page, "Alerting")

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -154,6 +154,7 @@ def click_tab_link(page, link_text):
 
 
 def wait_for_loading_finished(page):
+    page.get_by_label("Loading content").wait_for()
     expect(page.get_by_label("Loading content")).not_to_be_visible()
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add locator handlers to dismiss toast notifications quickly that intercept pointer events and slow down tests
- Update test helper waiting for loading to finish to assert that loading has started and then that it has finished

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The e2e alerting tests verify that access controls are working correctly.
