### PR TITLE
remove unreliable assertion waiting for loading status

### DIFF
--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -315,6 +315,8 @@ def delete_alert_monitor(page, monitor_name):
 
     expect(page.get_by_text(monitor_name, exact=True)).to_be_visible()
 
+    wait_for_loading_finished(page)
+
     select_table_item_checkbox(page, monitor_name)
 
     open_actions_menu(page)

--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -174,6 +174,7 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
     expect(page.get_by_role("heading", name="Edit SMTP sender")).to_be_visible()
 
     fill_email_smtp_sender_details(page, test_email_smtp_sender_name)
+    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update sender")
 
     click_contextual_menu_link(page, "Channels")
@@ -203,6 +204,7 @@ def test_user_can_see_but_not_edit_alert_objects(user_3, page):
     slack_webhook_input.wait_for()
     slack_webhook_input.fill("https://hooks.slack.com/services/foo/bar")
 
+    wait_for_loading_finished(page)
     failure_on_edit_save(page, "Failed to update channel")
 
     open_primary_menu_link(page, "Alerting")

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -154,7 +154,6 @@ def click_tab_link(page, link_text):
 
 
 def wait_for_loading_finished(page):
-    page.get_by_label("Loading content").wait_for()
     expect(page.get_by_label("Loading content")).not_to_be_visible()
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove unreliable assertion waiting for loading status from e2e tests, since the loading state is not deterministic

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The e2e alerting tests verify that access controls are working correctly.
