### PR TITLE
add a wait for loading to finish after clicking a monitor link

### DIFF
--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -347,6 +347,8 @@ def test_user_can_see_and_edit_alert_objects(user_4, page):
     expect(monitor_link).to_be_visible()
     monitor_link.click()
 
+    wait_for_loading_finished(page)
+
     expect(
         page.get_by_role("heading", name=test_monitor_name, exact=True)
     ).to_be_visible()


### PR DESCRIPTION
## Changes proposed in this pull request:

- add a wait for loading to finish after clicking a monitor link to ensure that page is stable before continuing with test assertions
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The e2e alerting tests verify that access controls are working correctly.