### PR TITLE
add explicit waiting for timestamp fields to reduce test flakiness

### DIFF
--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -362,6 +362,14 @@ def test_user_can_see_and_edit_alert_objects(user_4, page):
 
     wait_for_loading_finished(page)
 
+    time_field_input = page.get_by_text("@timestamp").first
+    time_field_input.wait_for()
+    time_field_input.click()
+
+    timestamp_option_button = page.get_by_role("option", name="@timestamp", exact=True)
+    expect(timestamp_option_button).to_be_visible()
+    timestamp_option_button.click()
+
     click_save_button(page)
     wait_for_loading_finished(page)
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- add explicit waiting for timestamp fields to reduce test flakiness
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. E2E tests verify that alerting access controls are working as expected
