### PR TITLE
try to fix flaky e2e test

### DIFF
--- a/e2e/test_alerting_access.py
+++ b/e2e/test_alerting_access.py
@@ -340,6 +340,10 @@ def test_user_can_see_and_edit_alert_objects(user_4, page):
 
     click_tab_link(page, "Monitors")
 
+    monitors_loading_message = page.get_by_text("Loading monitors")
+    monitors_loading_message.wait_for()
+    expect(monitors_loading_message).not_to_be_visible()
+
     update_rows_per_table(page)
     wait_for_loading_finished(page)
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- try to fix flaky test for editing an alert monitor by waiting for page loading state to fully resolve

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. The e2e tests verify that access controls for alerting access are working as expected.
