### PR TITLE
improve reliability of delete monitor test 

### DIFF
--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -310,6 +310,10 @@ def delete_email_smtp_sender(page, email_sender_name):
 
 
 def delete_alert_monitor(page, monitor_name):
+    monitors_loading_message = page.get_by_text("Loading monitors")
+    monitors_loading_message.wait_for()
+    expect(monitors_loading_message).not_to_be_visible()
+
     update_rows_per_table(page)
     wait_for_loading_finished(page)
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- improve reliability of delete monitor test by waiting for loading message to disappear before continuing with the test

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for the changes. The e2e alerting tests verify that alerting access controls are working as expected.
