### PR TITLE
add keystore credentials errand opsfile to prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1018,7 +1018,7 @@ jobs:
             - deploy-logs-opensearch-config/opsfiles/enable-syslog.yml
             - deploy-logs-opensearch-config/opsfiles/cf-production.yml
             - deploy-logs-opensearch-config/opsfiles/opensearch-notification.yml
-            # - deploy-logs-opensearch-config/opsfiles/add-keystore-credentials-errand.yml
+            - deploy-logs-opensearch-config/opsfiles/add-keystore-credentials-errand.yml
           vars_files:
             - terraform-secrets/terraform.yml
     on_failure:


### PR DESCRIPTION
## Changes proposed in this pull request:

- add keystore credentials errand opsfile to prod
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
