### PR TITLE
Fix e2e tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -733,13 +733,13 @@ jobs:
           - get: pipeline-tasks
           - get: deploy-logs-opensearch-config
             trigger: true
-            passed: [smoke-tests-development]
+            passed: [smoke-tests-development, e2e-tests-development]
           - get: opensearch-release
             trigger: true
-            passed: [smoke-tests-development]
+            passed: [smoke-tests-development, e2e-tests-development]
           - get: opensearch-stemcell-jammy
             trigger: true
-            passed: [smoke-tests-development]
+            passed: [smoke-tests-development, e2e-tests-development]
           - get: general-task
           - get: terraform-yaml
             resource: terraform-yaml-staging
@@ -973,13 +973,13 @@ jobs:
           - get: pipeline-tasks
           - get: deploy-logs-opensearch-config
             trigger: true
-            passed: [smoke-tests-staging]
+            passed: [smoke-tests-staging, e2e-tests-staging]
           - get: opensearch-release
             trigger: true
-            passed: [smoke-tests-staging]
+            passed: [smoke-tests-staging, e2e-tests-staging]
           - get: opensearch-stemcell-jammy
             trigger: true
-            passed: [smoke-tests-staging]
+            passed: [smoke-tests-staging, e2e-tests-staging]
           - get: terraform-yaml
             resource: terraform-yaml-production
             trigger: true

--- a/e2e/notifications.py
+++ b/e2e/notifications.py
@@ -27,8 +27,8 @@ def fill_email_recipient_group_details(page, user, email_recipient_group_name):
     group_name_input.fill(email_recipient_group_name)
 
     email_address_input = (
-        page.locator("div")
-        .filter(has_text=re.compile(r"^Email addresses$"))
+        page.locator("css=.euiFormRow")
+        .filter(has=page.get_by_text("Emails"))
         .get_by_role("textbox")
     )
     email_address_input.fill(user.username)

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 python -m venv venv
+# shellcheck disable=SC1091
 source venv/bin/activate
 pip install -r requirements-test.txt
 playwright install firefox


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix selector in E2E tests
- Fix script warning
- Make E2E tests required in pipeline

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None for these changes. In general, the E2E tests verify that access controls for alerting are working correctly
