### PR TITLE
add default locale setting when running tests via Playwright

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -8,6 +8,14 @@ from .user import User
 expect.set_options(timeout=60_000)
 
 
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):
+    browser_context_args["locale"] = "en-US"
+    return {
+        **browser_context_args,
+    }
+
+
 @pytest.fixture
 def user_1():
     user_1_username = getenv(f"TEST_USER_1_USERNAME")


### PR DESCRIPTION
## Changes proposed in this pull request:

- add default locale setting when running tests via Playwright to possibly fix test failures 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There is no change to the actual behavior of OpenSearch, just a possible fix for test failures.
