### PR TITLE
Simplify ingestors, up ingestors, remove logsearch

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1347,7 +1347,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/opensearch-boshrelease
-      branch:  platform-snapshot
+      branch: ((test-opensearch-release-branch))
 
   - name: opensearch-final-builds-dir-tarball
     type: s3-iam
@@ -1412,7 +1412,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/deploy-logs-opensearch.git
-      branch: staging
+      branch: ((deploy-logs-opensearch-config-test-branch))
 
   - name: opensearch-stemcell-jammy
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -432,6 +432,7 @@ jobs:
           stemcells:
             - opensearch-stemcell-jammy/*.tgz
           ops_files:
+            - deploy-logs-opensearch-test-config/opsfiles/shared-ingestor-properties.yml
             - deploy-logs-opensearch-test-config/opsfiles/enable-node-tls.yml
             - deploy-logs-opensearch-test-config/opsfiles/enable-dashboard-dns.yml
             - deploy-logs-opensearch-test-config/opsfiles/enable-dashboards-tls.yml
@@ -551,6 +552,7 @@ jobs:
           stemcells:
             - opensearch-stemcell-jammy/*.tgz
           ops_files:
+            - deploy-logs-opensearch-config/opsfiles/shared-ingestor-properties.yml
             - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
             - deploy-logs-opensearch-config/opsfiles/enable-dashboard-dns.yml
             - deploy-logs-opensearch-config/opsfiles/enable-dashboards-tls.yml
@@ -791,6 +793,7 @@ jobs:
           stemcells:
             - opensearch-stemcell-jammy/*.tgz
           ops_files:
+            - deploy-logs-opensearch-config/opsfiles/shared-ingestor-properties.yml
             - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
             - deploy-logs-opensearch-config/opsfiles/enable-dashboard-dns.yml
             - deploy-logs-opensearch-config/opsfiles/enable-dashboards-tls.yml
@@ -1034,6 +1037,7 @@ jobs:
           stemcells:
             - opensearch-stemcell-jammy/*.tgz
           ops_files:
+            - deploy-logs-opensearch-config/opsfiles/shared-ingestor-properties.yml
             - deploy-logs-opensearch-config/opsfiles/enable-node-tls.yml
             - deploy-logs-opensearch-config/opsfiles/enable-dashboard-dns.yml
             - deploy-logs-opensearch-config/opsfiles/enable-dashboards-tls.yml
@@ -1343,7 +1347,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/opensearch-boshrelease
-      branch:  ((test-opensearch-release-branch))
+      branch:  platform-snapshot
 
   - name: opensearch-final-builds-dir-tarball
     type: s3-iam
@@ -1408,7 +1412,7 @@ resources:
     source:
       commit_verification_keys: ((cloud-gov-pgp-keys))
       uri: https://github.com/cloud-gov/deploy-logs-opensearch.git
-      branch: ((deploy-logs-opensearch-config-test-branch))
+      branch: staging
 
   - name: opensearch-stemcell-jammy
     source:

--- a/opensearch-base.yml
+++ b/opensearch-base.yml
@@ -46,8 +46,6 @@ instance_groups:
         ip_addresses: true
     properties:
       opensearch:
-        anomaly_detection: &opensearch-anomaly-detection
-          enabled: true
         deployment_type: &opensearch-deployment-type
         - app
         - metric
@@ -94,7 +92,6 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        anomaly_detection: *opensearch-anomaly-detection
         deployment_type: *opensearch-deployment-type
         node:
           attributes:
@@ -148,7 +145,6 @@ instance_groups:
         as: opensearch_manager
     properties:
       opensearch:
-        anomaly_detection: *opensearch-anomaly-detection
         deployment_type: *opensearch-deployment-type
         clustername: opensearch
         limits:
@@ -191,7 +187,6 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        anomaly_detection: *opensearch-anomaly-detection
         deployment_type: *opensearch-deployment-type
         clustername: opensearch
         limits:
@@ -336,7 +331,6 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        anomaly_detection: *opensearch-anomaly-detection
         deployment_type: *opensearch-deployment-type
         jvm_options: *opensearch-jvm-options
         migrate_data_path: true
@@ -394,7 +388,6 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        anomaly_detection: *opensearch-anomaly-detection
         deployment_type: *opensearch-deployment-type
         heap_size: 1G
         http_host: 127.0.0.1
@@ -586,7 +579,6 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        anomaly_detection: *opensearch-anomaly-detection
         deployment_type: *opensearch-deployment-type
         heap_size: 1G
         http_host: 127.0.0.1

--- a/opensearch-base.yml
+++ b/opensearch-base.yml
@@ -46,7 +46,9 @@ instance_groups:
         ip_addresses: true
     properties:
       opensearch:
-        deployment_type:
+        anomaly_detection: &opensearch-anomaly-detection
+          enabled: true
+        deployment_type: &opensearch-deployment-type
         - app
         - metric
         node:
@@ -63,8 +65,8 @@ instance_groups:
           delay_allocation_restart: "15m"
         config_options:
           indices.query.bool.max_clause_count: 2048
-        jvm_options:
-          - "-Dlog4j2.formatMsgNoLookups=true"
+        jvm_options: &opensearch-jvm-options
+        - "-Dlog4j2.formatMsgNoLookups=true"
         cf:
           client_id: opensearch_client_id
   persistent_disk_type: logs_opensearch_os_old_data
@@ -92,9 +94,8 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        deployment_type:
-        - app
-        - metric
+        anomaly_detection: *opensearch-anomaly-detection
+        deployment_type: *opensearch-deployment-type
         node:
           attributes:
             box_type: hot
@@ -109,8 +110,7 @@ instance_groups:
           delay_allocation_restart: "10m"
         config_options:
           indices.query.bool.max_clause_count: 2048
-        jvm_options:
-          - "-Dlog4j2.formatMsgNoLookups=true"
+        jvm_options: *opensearch-jvm-options
         cf:
           client_id: opensearch_client_id
   persistent_disk_type: logs_opensearch_os_data
@@ -148,14 +148,12 @@ instance_groups:
         as: opensearch_manager
     properties:
       opensearch:
-        deployment_type:
-        - app
-        - metric
+        anomaly_detection: *opensearch-anomaly-detection
+        deployment_type: *opensearch-deployment-type
         clustername: opensearch
         limits:
           fd: 131072 # 2 ** 17
-        jvm_options:
-          - "-Dlog4j2.formatMsgNoLookups=true"
+        jvm_options: *opensearch-jvm-options
         node:
           allow_cluster_manager: true
           allow_data: false
@@ -193,14 +191,12 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        deployment_type:
-        - app
-        - metric
+        anomaly_detection: *opensearch-anomaly-detection
+        deployment_type: *opensearch-deployment-type
         clustername: opensearch
         limits:
           fd: 131072 # 2 ** 17
-        jvm_options:
-          - "-Dlog4j2.formatMsgNoLookups=true"
+        jvm_options: *opensearch-jvm-options
   - consumes:
       ingestor_link:
         from: ingestor_syslog
@@ -340,11 +336,9 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        deployment_type:
-        - app
-        - metric
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
+        anomaly_detection: *opensearch-anomaly-detection
+        deployment_type: *opensearch-deployment-type
+        jvm_options: *opensearch-jvm-options
         migrate_data_path: true
     release: opensearch
   - consumes:
@@ -400,19 +394,16 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        deployment_type:
-        - app
-        - metric
+        anomaly_detection: *opensearch-anomaly-detection
+        deployment_type: *opensearch-deployment-type
         heap_size: 1G
         http_host: 127.0.0.1
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
+        jvm_options: *opensearch-jvm-options
   - name: ingestor_syslog
     consumes: *consumes-opensearch-manager
     properties:
       logstash:
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
+        jvm_options: *opensearch-jvm-options
         queue:
           max_bytes: 30gb
       logstash_ingestor:
@@ -454,6 +445,10 @@ instance_groups:
   update:
     serial: true # Block on this job to create deploy group 5
 
+# NOTE: opensearch/logstash/parser/ssl and instance-group infra properties
+# common to all S3 ingestors live in opsfiles/shared-ingestor-properties.yml.
+# Only the differentiating fields (logstash.type, s3.bucket, parser index) are
+# kept here.
 - name: ingestor_s3
   instances: 1
   jobs:
@@ -462,57 +457,25 @@ instance_groups:
   - name: opensearch
     release: opensearch
     consumes: *consumes-opensearch-manager
-    properties:
-      opensearch:
-        deployment_type:
-        - app
-        - metric
-        heap_size: 1G
-        http_host: 127.0.0.1
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
   - consumes: *consumes-opensearch-manager
     name: ingestor_s3
     properties:
       logstash:
         type: audit
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
-        queue:
-          max_bytes: 30gb
       logstash_ingestor:
         s3:
           bucket: ((audit_bucket))
           region: ((region))
-        syslog_tls:
-          port: 6972
-          ssl_cert: ((ingestor_syslog_server_tls.certificate))
-          ssl_key: ((ingestor_syslog_server_tls.private_key))
       logstash_parser:
         opensearch:
-          data_hosts:
-          - localhost
           index: ((alias))
           index_type: '%{@type}'
-          ssl:
-            ca: ((opensearch_node.ca))
-            certificate: ((logstash.certificate))
-            private_key: ((logstash.private_key))
     provides:
       ingestor:
         as: ingestor_s3
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  azs: [z1,z2]
-  networks:
-  - name: services
-  persistent_disk_type: logs_opensearch_ingestor
-  stemcell: default
-  vm_extensions:
-  - logs-opensearch-ingestor-profile
-  - 20GB_ephemeral_disk
-  vm_type: t3.large
   update:
     serial: true # Block on this job to create deploy group 6
 
@@ -524,57 +487,25 @@ instance_groups:
   - name: opensearch
     release: opensearch
     consumes: *consumes-opensearch-manager
-    properties:
-      opensearch:
-        deployment_type:
-        - app
-        - metric
-        heap_size: 1G
-        http_host: 127.0.0.1
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
   - consumes: *consumes-opensearch-manager
     name: ingestor_s3
     properties:
       logstash:
         type: metric
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
-        queue:
-          max_bytes: 30gb
       logstash_ingestor:
         s3:
           bucket: ((metric_stream_bucket))
           region: ((region))
-        syslog_tls:
-          port: 6972
-          ssl_cert: ((ingestor_syslog_server_tls.certificate))
-          ssl_key: ((ingestor_syslog_server_tls.private_key))
       logstash_parser:
         opensearch:
-          data_hosts:
-          - localhost
           index: ((metric_alias))
           index_type: '%{@type}'
-          ssl:
-            ca: ((opensearch_node.ca))
-            certificate: ((logstash.certificate))
-            private_key: ((logstash.private_key))
     provides:
       ingestor:
         as: ingestor_s3
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  azs: [z1,z2]
-  networks:
-  - name: services
-  persistent_disk_type: logs_opensearch_ingestor
-  stemcell: default
-  vm_extensions:
-  - logs-opensearch-ingestor-profile
-  - 20GB_ephemeral_disk
-  vm_type: t3.large
   update:
     serial: true # Block on this job to create deploy group 6
 
@@ -586,57 +517,25 @@ instance_groups:
   - name: opensearch
     release: opensearch
     consumes: *consumes-opensearch-manager
-    properties:
-      opensearch:
-        deployment_type:
-        - app
-        - metric
-        heap_size: 1G
-        http_host: 127.0.0.1
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
   - consumes: *consumes-opensearch-manager
     name: ingestor_s3
     properties:
       logstash:
         type: cloudwatch
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
-        queue:
-          max_bytes: 30gb
       logstash_ingestor:
         s3:
           bucket: ((cloudwatch_bucket))
           region: ((region))
-        syslog_tls:
-          port: 6972
-          ssl_cert: ((ingestor_syslog_server_tls.certificate))
-          ssl_key: ((ingestor_syslog_server_tls.private_key))
       logstash_parser:
         opensearch:
-          data_hosts:
-          - localhost
           index: ((alias))
           index_type: '%{@type}'
-          ssl:
-            ca: ((opensearch_node.ca))
-            certificate: ((logstash.certificate))
-            private_key: ((logstash.private_key))
     provides:
       ingestor:
         as: ingestor_s3
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  persistent_disk_type: logs_opensearch_ingestor
-  stemcell: default
-  azs: [z1,z2]
-  vm_type: t3.large
-  vm_extensions:
-  - logs-opensearch-ingestor-profile
-  - 20GB_ephemeral_disk
-  networks:
-  - name: services
   update:
     serial: true # Block on this job to create deploy group 7
 
@@ -648,58 +547,26 @@ instance_groups:
   - name: opensearch
     release: opensearch
     consumes: *consumes-opensearch-manager
-    properties:
-      opensearch:
-        deployment_type:
-        - app
-        - metric
-        heap_size: 1G
-        http_host: 127.0.0.1
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
   - consumes: *consumes-opensearch-manager
     name: ingestor_s3
     properties:
       logstash:
         type: falco
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
-        queue:
-          max_bytes: 30gb
       logstash_ingestor:
         s3:
           bucket: ((falco_bucket))
           region: ((region))
           prefix: falco
-        syslog_tls:
-          port: 6972
-          ssl_cert: ((ingestor_syslog_server_tls.certificate))
-          ssl_key: ((ingestor_syslog_server_tls.private_key))
       logstash_parser:
         opensearch:
-          data_hosts:
-          - localhost
           index: ((alias))
           index_type: '%{@type}'
-          ssl:
-            ca: ((opensearch_node.ca))
-            certificate: ((logstash.certificate))
-            private_key: ((logstash.private_key))
     provides:
       ingestor:
         as: ingestor_s3
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  persistent_disk_type: logs_opensearch_ingestor
-  stemcell: default
-  azs: [z1,z2]
-  vm_type: t3.large
-  vm_extensions:
-  - logs-opensearch-ingestor-profile
-  - 20GB_ephemeral_disk
-  networks:
-  - name: services
   update:
     serial: true # Block on this job to create deploy group 8
 
@@ -719,13 +586,11 @@ instance_groups:
     consumes: *consumes-opensearch-manager
     properties:
       opensearch:
-        deployment_type:
-        - app
-        - metric
+        anomaly_detection: *opensearch-anomaly-detection
+        deployment_type: *opensearch-deployment-type
         heap_size: 1G
         http_host: 127.0.0.1
-        jvm_options:
-        - -Dlog4j2.formatMsgNoLookups=true
+        jvm_options: *opensearch-jvm-options
   - name: opensearch_dashboards
     consumes: *consumes-opensearch-manager
     properties:

--- a/opensearch-scaling-production.yml
+++ b/opensearch-scaling-production.yml
@@ -68,7 +68,7 @@
 
 - type: replace
   path: /instance_groups/name=ingestor?/instances?
-  value: 12
+  value: 14
 
 - type: replace
   path: /instance_groups/name=ingestor?/vm_type?

--- a/opsfiles/shared-ingestor-properties.yml
+++ b/opsfiles/shared-ingestor-properties.yml
@@ -1,0 +1,240 @@
+---
+# OPS file to consolidate the properties shared by every S3-backed ingestor
+# instance group (ingestor_s3, ingestor_aws_metrics, ingestor_cloudwatch_logs,
+# ingestor_falco). These groups are ~95% identical in opensearch-base.yml; the
+# only per-group differences are logstash.type, the s3 bucket, the parser index,
+# the s3 prefix and the "provides" name. Everything below is common to all of
+# them and is applied here via replace ops so the base manifest stays DRY.
+#
+# NOTE: this ops file only touches properties that are identical across the
+# groups. Differentiating fields (type/bucket/index/prefix/provides) remain in
+# opensearch-base.yml.
+
+# ---------------------------------------------------------------------------
+# Shared "opensearch" sidecar job properties (identical for all ingestors)
+# ---------------------------------------------------------------------------
+- type: replace
+  path: /instance_groups/name=ingestor_s3/jobs/name=opensearch/properties/opensearch?
+  value: &ingestor-opensearch-properties
+    anomaly_detection:
+      enabled: true
+    deployment_type:
+    - app
+    - metric
+    heap_size: 1G
+    http_host: 127.0.0.1
+    jvm_options:
+    - -Dlog4j2.formatMsgNoLookups=true
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/jobs/name=opensearch/properties/opensearch?
+  value: *ingestor-opensearch-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/jobs/name=opensearch/properties/opensearch?
+  value: *ingestor-opensearch-properties
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/jobs/name=opensearch/properties/opensearch?
+  value: *ingestor-opensearch-properties
+
+# ---------------------------------------------------------------------------
+# Shared logstash jvm_options + queue tuning
+# ---------------------------------------------------------------------------
+- type: replace
+  path: /instance_groups/name=ingestor_s3/jobs/name=ingestor_s3/properties/logstash/jvm_options?
+  value: &ingestor-logstash-jvm-options
+  - -Dlog4j2.formatMsgNoLookups=true
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/jobs/name=ingestor_s3/properties/logstash/queue?
+  value: &ingestor-logstash-queue
+    max_bytes: 30gb
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/jobs/name=ingestor_s3/properties/logstash/jvm_options?
+  value: *ingestor-logstash-jvm-options
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/jobs/name=ingestor_s3/properties/logstash/queue?
+  value: *ingestor-logstash-queue
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/jobs/name=ingestor_s3/properties/logstash/jvm_options?
+  value: *ingestor-logstash-jvm-options
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/jobs/name=ingestor_s3/properties/logstash/queue?
+  value: *ingestor-logstash-queue
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/jobs/name=ingestor_s3/properties/logstash/jvm_options?
+  value: *ingestor-logstash-jvm-options
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/jobs/name=ingestor_s3/properties/logstash/queue?
+  value: *ingestor-logstash-queue
+
+# ---------------------------------------------------------------------------
+# Shared syslog_tls listener config
+# ---------------------------------------------------------------------------
+- type: replace
+  path: /instance_groups/name=ingestor_s3/jobs/name=ingestor_s3/properties/logstash_ingestor/syslog_tls?
+  value: &ingestor-syslog-tls
+    port: 6972
+    ssl_cert: ((ingestor_syslog_server_tls.certificate))
+    ssl_key: ((ingestor_syslog_server_tls.private_key))
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/jobs/name=ingestor_s3/properties/logstash_ingestor/syslog_tls?
+  value: *ingestor-syslog-tls
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/jobs/name=ingestor_s3/properties/logstash_ingestor/syslog_tls?
+  value: *ingestor-syslog-tls
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/jobs/name=ingestor_s3/properties/logstash_ingestor/syslog_tls?
+  value: *ingestor-syslog-tls
+
+# ---------------------------------------------------------------------------
+# Shared logstash_parser opensearch data_hosts + ssl
+# (index / index_type stay per-group in the base manifest)
+# ---------------------------------------------------------------------------
+- type: replace
+  path: /instance_groups/name=ingestor_s3/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/data_hosts?
+  value: &ingestor-parser-data-hosts
+  - localhost
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/ssl?
+  value: &ingestor-parser-ssl
+    ca: ((opensearch_node.ca))
+    certificate: ((logstash.certificate))
+    private_key: ((logstash.private_key))
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/data_hosts?
+  value: *ingestor-parser-data-hosts
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/ssl?
+  value: *ingestor-parser-ssl
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/data_hosts?
+  value: *ingestor-parser-data-hosts
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/ssl?
+  value: *ingestor-parser-ssl
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/data_hosts?
+  value: *ingestor-parser-data-hosts
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/jobs/name=ingestor_s3/properties/logstash_parser/opensearch/ssl?
+  value: *ingestor-parser-ssl
+
+# ---------------------------------------------------------------------------
+# Shared instance-group level infrastructure settings
+# ---------------------------------------------------------------------------
+- type: replace
+  path: /instance_groups/name=ingestor_s3/azs?
+  value: &ingestor-azs [z1, z2]
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/networks?
+  value: &ingestor-networks
+  - name: services
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/persistent_disk_type?
+  value: &ingestor-disk logs_opensearch_ingestor
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/stemcell?
+  value: &ingestor-stemcell default
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/vm_extensions?
+  value: &ingestor-vm-extensions
+  - logs-opensearch-ingestor-profile
+  - 20GB_ephemeral_disk
+
+- type: replace
+  path: /instance_groups/name=ingestor_s3/vm_type?
+  value: &ingestor-vm-type t3.large
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/azs?
+  value: *ingestor-azs
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/networks?
+  value: *ingestor-networks
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/persistent_disk_type?
+  value: *ingestor-disk
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/stemcell?
+  value: *ingestor-stemcell
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/vm_extensions?
+  value: *ingestor-vm-extensions
+
+- type: replace
+  path: /instance_groups/name=ingestor_aws_metrics/vm_type?
+  value: *ingestor-vm-type
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/azs?
+  value: *ingestor-azs
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/networks?
+  value: *ingestor-networks
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/persistent_disk_type?
+  value: *ingestor-disk
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/stemcell?
+  value: *ingestor-stemcell
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/vm_extensions?
+  value: *ingestor-vm-extensions
+
+- type: replace
+  path: /instance_groups/name=ingestor_cloudwatch_logs/vm_type?
+  value: *ingestor-vm-type
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/azs?
+  value: *ingestor-azs
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/networks?
+  value: *ingestor-networks
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/persistent_disk_type?
+  value: *ingestor-disk
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/stemcell?
+  value: *ingestor-stemcell
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/vm_extensions?
+  value: *ingestor-vm-extensions
+
+- type: replace
+  path: /instance_groups/name=ingestor_falco/vm_type?
+  value: *ingestor-vm-type

--- a/opsfiles/shared-ingestor-properties.yml
+++ b/opsfiles/shared-ingestor-properties.yml
@@ -16,8 +16,6 @@
 - type: replace
   path: /instance_groups/name=ingestor_s3/jobs/name=opensearch/properties/opensearch?
   value: &ingestor-opensearch-properties
-    anomaly_detection:
-      enabled: true
     deployment_type:
     - app
     - metric

--- a/varsfiles/terraform.yml
+++ b/varsfiles/terraform.yml
@@ -1,5 +1,4 @@
 redis_host: ((terraform_outputs.opensearch_proxy_redis_cluster.host))
 redis_password: ((terraform_outputs.opensearch_proxy_redis_cluster.password))
-logsearch_archive_bucket_name: ((terraform_outputs.logsearch_archive_bucket_name))
 opensearch_archive_bucket_name: ((terraform_outputs.logs_opensearch_archive_bucket_name))
 vpc_region: ((terraform_outputs.vpc_region))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Ingestor jobs lower duplication in base file
- we need 2 more ingestors in prod to take surge
- logsearch terraform is gone now


## Security considerations
None
