### PR TITLE
update instance type for opensearch ingestors

### DIFF
--- a/opensearch-scaling-production.yml
+++ b/opensearch-scaling-production.yml
@@ -20,7 +20,7 @@
 
 - type: replace
   path: /instance_groups/name=opensearch_data?/update?
-  value: 
+  value:
     max_in_flight: 1
     canaries: 1
     serial: true
@@ -36,7 +36,7 @@
 
 - type: replace
   path: /instance_groups/name=opensearch_old_data?/update?
-  value: 
+  value:
     max_in_flight: 1
     canaries: 1
     serial: true
@@ -51,7 +51,7 @@
 
 - type: replace
   path: /instance_groups/name=opensearch_dashboards/update?
-  value: 
+  value:
     max_in_flight: 100%
     canaries: 100%
     serial: true
@@ -72,7 +72,7 @@
 
 - type: replace
   path: /instance_groups/name=ingestor?/vm_type?
-  value: r6i.xlarge.logsearch.ingestor
+  value: r6i.xlarge.opensearch.ingestor
 
 - type: replace
   path: /instance_groups/name=ingestor_cloudwatch_logs?/instances?

--- a/prod-opensearch-ingestors.yml
+++ b/prod-opensearch-ingestors.yml
@@ -63,7 +63,7 @@ instance_groups:
     release: opensearch
   - name: deployment_lookup_config
     release: opensearch
-  vm_type: r6i.xlarge.logsearch.ingestor
+  vm_type: r6i.xlarge.opensearch.ingestor
   networks:
   - name: services
   persistent_disk_type: logs_opensearch_ingestor


### PR DESCRIPTION
## Changes proposed in this pull request:

- update ingestor type for opensearch ingestors to deprecate instance type for logsearch

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None